### PR TITLE
Feat/audio buffer copy methods

### DIFF
--- a/apps/common-app/src/examples/SharedUtils/soundEngines/Clap.ts
+++ b/apps/common-app/src/examples/SharedUtils/soundEngines/Clap.ts
@@ -33,7 +33,7 @@ class Clap implements SoundEngine {
       output[i] = Math.random() * 2 - 1;
     }
 
-    buffer.setChannelData(0, output);
+    buffer.copyToChannel(output, 0, 0);
 
     return buffer;
   }

--- a/docs/web-audio-coverage.md
+++ b/docs/web-audio-coverage.md
@@ -7,13 +7,19 @@ Some of the noticeable implementation details that are still in progress or not 
 - Support of different number of channels (current approach in most of the audio-graph nodes assumes working with two channel audio)
 - Multi-input for each node and input mixing (Although specification suggests that most of the nodes can cave only one input or output, common use-cases proves otherwise). Only node that mixes multiple inputs is `DestinationNode`.
 
-## ✅ Completed (**5** out of 33)
+## ✅ Completed (**6** out of 33)
 
 <details>
- <summary><b>AudioScheduledSourceNode</b></summary>
+  <summary><b>AudioBuffer</b></summary>
 </details>
 <details>
  <summary><b>AudioDestinationNode</b></summary>
+</details>
+<details>
+ <summary><b>AudioNode</b></summary>
+</details>
+<details>
+ <summary><b>AudioScheduledSourceNode</b></summary>
 </details>
 <details>
  <summary><b>GainNode</b></summary>
@@ -21,11 +27,8 @@ Some of the noticeable implementation details that are still in progress or not 
 <details>
  <summary><b>StereoPannerNode</b></summary>
 </details>
-<details>
- <summary><b>AudioNode</b></summary>
-</details>
 
-## 🚧 In Progress (**7** out of 33)
+## 🚧 In Progress (**6** out of 33)
 
 <details>
   <summary><b>AudioContext</b></summary>
@@ -44,27 +47,6 @@ Some of the noticeable implementation details that are still in progress or not 
 | 🔘 resume                       | ❌    |
 | 🔘 setSinkId                    | ❌    |
 | 🔘 suspend                      | ❌    |
-
-</div>
-
-</details>
-
-<details>
-  <summary><b>AudioBuffer</b></summary>
-
-<div style="padding: 16px; padding-left: 42px;">
-
-| Property 🔹/ Method 🔘 | state |
-| ---------------------- | ----- |
-| 🔹 sampleRate          | ✅    |
-| 🔹 length              | ✅    |
-| 🔹 duration            | ✅    |
-| 🔹 numberOfChannels    | ✅    |
-| 🔘 getChannelData      | ✅    |
-| 🔘 getChannelData      | ✅    |
-| 🔘 setChannelData      | ✅    |
-| 🔘 copyFromChannel     | ❌    |
-| 🔘 copyToChannel       | ❌    |
 
 </div>
 

--- a/packages/react-native-audio-api/common/cpp/HostObjects/AudioBufferHostObject.cpp
+++ b/packages/react-native-audio-api/common/cpp/HostObjects/AudioBufferHostObject.cpp
@@ -17,7 +17,6 @@ std::vector<jsi::PropNameID> AudioBufferHostObject::getPropertyNames(
   propertyNames.push_back(
       jsi::PropNameID::forAscii(runtime, "numberOfChannels"));
   propertyNames.push_back(jsi::PropNameID::forAscii(runtime, "getChannelData"));
-  propertyNames.push_back(jsi::PropNameID::forAscii(runtime, "setChannelData"));
   propertyNames.push_back(
       jsi::PropNameID::forAscii(runtime, "copyFromChannel"));
   propertyNames.push_back(jsi::PropNameID::forAscii(runtime, "copyToChannel"));
@@ -64,31 +63,6 @@ jsi::Value AudioBufferHostObject::get(
           }
 
           return array;
-        });
-  }
-
-  if (propName == "setChannelData") {
-    return jsi::Function::createFromHostFunction(
-        runtime,
-        propNameId,
-        2,
-        [this](
-            jsi::Runtime &rt,
-            const jsi::Value &thisVal,
-            const jsi::Value *args,
-            size_t count) -> jsi::Value {
-          int channel = static_cast<int>(args[0].getNumber());
-          auto array = args[1].getObject(rt).asArray(rt);
-          auto *channelData = new float[wrapper_->getLength()];
-
-          for (int i = 0; i < wrapper_->getLength(); i++) {
-            channelData[i] =
-                static_cast<float>(array.getValueAtIndex(rt, i).getNumber());
-          }
-
-          wrapper_->setChannelData(channel, channelData, wrapper_->getLength());
-
-          return jsi::Value::undefined();
         });
   }
 

--- a/packages/react-native-audio-api/common/cpp/HostObjects/AudioBufferHostObject.cpp
+++ b/packages/react-native-audio-api/common/cpp/HostObjects/AudioBufferHostObject.cpp
@@ -18,6 +18,9 @@ std::vector<jsi::PropNameID> AudioBufferHostObject::getPropertyNames(
       jsi::PropNameID::forAscii(runtime, "numberOfChannels"));
   propertyNames.push_back(jsi::PropNameID::forAscii(runtime, "getChannelData"));
   propertyNames.push_back(jsi::PropNameID::forAscii(runtime, "setChannelData"));
+  propertyNames.push_back(
+      jsi::PropNameID::forAscii(runtime, "copyFromChannel"));
+  propertyNames.push_back(jsi::PropNameID::forAscii(runtime, "copyToChannel"));
   return propertyNames;
 }
 
@@ -84,6 +87,68 @@ jsi::Value AudioBufferHostObject::get(
           }
 
           wrapper_->setChannelData(channel, channelData, wrapper_->getLength());
+
+          return jsi::Value::undefined();
+        });
+  }
+
+  if (propName == "copyFromChannel") {
+    return jsi::Function::createFromHostFunction(
+        runtime,
+        propNameId,
+        3,
+        [this](
+            jsi::Runtime &rt,
+            const jsi::Value &thisVal,
+            const jsi::Value *args,
+            size_t count) -> jsi::Value {
+          auto destination = args[0].getObject(rt).asArray(rt);
+          auto destinationLength = static_cast<int>(
+              destination.getProperty(rt, "length").asNumber());
+          auto channelNumber = static_cast<int>(args[1].getNumber());
+          auto startInChannel = static_cast<int>(args[2].getNumber());
+
+          auto *destinationData = new float[destinationLength];
+
+          wrapper_->copyFromChannel(
+              destinationData,
+              destinationLength,
+              channelNumber,
+              startInChannel);
+
+          for (int i = 0; i < destinationLength; i++) {
+            destination.setValueAtIndex(rt, i, jsi::Value(destinationData[i]));
+          }
+
+          return jsi::Value::undefined();
+        });
+  }
+
+  if (propName == "copyToChannel") {
+    return jsi::Function::createFromHostFunction(
+        runtime,
+        propNameId,
+        3,
+        [this](
+            jsi::Runtime &rt,
+            const jsi::Value &thisVal,
+            const jsi::Value *args,
+            size_t count) -> jsi::Value {
+          auto source = args[0].getObject(rt).asArray(rt);
+          auto sourceLength =
+              static_cast<int>(source.getProperty(rt, "length").asNumber());
+          auto channelNumber = static_cast<int>(args[1].getNumber());
+          auto startInChannel = static_cast<int>(args[2].getNumber());
+
+          auto *sourceData = new float[sourceLength];
+
+          for (int i = 0; i < sourceLength; i++) {
+            sourceData[i] =
+                static_cast<float>(source.getValueAtIndex(rt, i).getNumber());
+          }
+
+          wrapper_->copyToChannel(
+              sourceData, sourceLength, channelNumber, startInChannel);
 
           return jsi::Value::undefined();
         });

--- a/packages/react-native-audio-api/common/cpp/core/AudioBuffer.cpp
+++ b/packages/react-native-audio-api/common/cpp/core/AudioBuffer.cpp
@@ -85,4 +85,43 @@ std::shared_ptr<AudioBuffer> AudioBuffer::mix(int outputNumberOfChannels) {
 
   return mixedBuffer;
 }
+
+void AudioBuffer::copyFromChannel(
+    float *destination,
+    int destinationLength,
+    int channelNumber,
+    int startInChannel) const {
+  if (channelNumber < 0 || channelNumber >= numberOfChannels_) {
+    throw std::invalid_argument("Invalid channel number");
+  }
+
+  if (startInChannel < 0 || startInChannel >= length_) {
+    throw std::invalid_argument("Invalid start in channel");
+  }
+
+  std::copy(
+      channels_[channelNumber] + startInChannel,
+      channels_[channelNumber] + startInChannel +
+          std::min(destinationLength, length_ - startInChannel),
+      destination);
+}
+
+void AudioBuffer::copyToChannel(
+    const float *source,
+    int sourceLength,
+    int channelNumber,
+    int startInChannel) {
+  if (channelNumber < 0 || channelNumber >= numberOfChannels_) {
+    throw std::invalid_argument("Invalid channel number");
+  }
+
+  if (startInChannel < 0 || startInChannel >= length_) {
+    throw std::invalid_argument("Invalid start in channel");
+  }
+
+  std::copy(
+      source,
+      source + std::min(sourceLength, length_ - startInChannel),
+      channels_[channelNumber] + startInChannel);
+}
 } // namespace audioapi

--- a/packages/react-native-audio-api/common/cpp/core/AudioBuffer.cpp
+++ b/packages/react-native-audio-api/common/cpp/core/AudioBuffer.cpp
@@ -46,18 +46,6 @@ float *AudioBuffer::getChannelData(int channel) const {
   return channels_[channel];
 }
 
-void AudioBuffer::setChannelData(int channel, const float *data, int length) {
-  if (channel < 0 || channel >= numberOfChannels_) {
-    throw std::invalid_argument("Invalid channel number");
-  }
-
-  if (length != length_) {
-    throw std::invalid_argument("Invalid data length");
-  }
-
-  std::copy(data, data + length, channels_[channel]);
-}
-
 std::shared_ptr<AudioBuffer> AudioBuffer::mix(int outputNumberOfChannels) {
   if (outputNumberOfChannels != 1 && outputNumberOfChannels != 2) {
     throw std::invalid_argument("Invalid number of channels");
@@ -72,8 +60,8 @@ std::shared_ptr<AudioBuffer> AudioBuffer::mix(int outputNumberOfChannels) {
 
   switch (this->numberOfChannels_) {
     case 1:
-      mixedBuffer->setChannelData(0, this->channels_[0], length_);
-      mixedBuffer->setChannelData(1, this->channels_[0], length_);
+      mixedBuffer->copyToChannel(this->channels_[0], length_, 0, 0);
+      mixedBuffer->copyToChannel(this->channels_[0], length_, 1, 0);
       break;
     case 2:
       for (int i = 0; i < length_; i++) {

--- a/packages/react-native-audio-api/common/cpp/core/AudioBuffer.h
+++ b/packages/react-native-audio-api/common/cpp/core/AudioBuffer.h
@@ -17,6 +17,16 @@ class AudioBuffer : public std::enable_shared_from_this<AudioBuffer> {
   double getDuration() const;
   float *getChannelData(int channel) const;
   void setChannelData(int channel, const float *data, int length);
+  void copyFromChannel(
+      float *destination,
+      int destinationLength,
+      int channelNumber,
+      int startInChannel) const;
+  void copyToChannel(
+      const float *source,
+      int sourceLength,
+      int channelNumber,
+      int startInChannel);
 
  private:
   friend class AudioBufferSourceNode;

--- a/packages/react-native-audio-api/common/cpp/core/AudioBuffer.h
+++ b/packages/react-native-audio-api/common/cpp/core/AudioBuffer.h
@@ -16,7 +16,6 @@ class AudioBuffer : public std::enable_shared_from_this<AudioBuffer> {
   int getSampleRate() const;
   double getDuration() const;
   float *getChannelData(int channel) const;
-  void setChannelData(int channel, const float *data, int length);
   void copyFromChannel(
       float *destination,
       int destinationLength,

--- a/packages/react-native-audio-api/common/cpp/wrappers/AudioBufferWrapper.cpp
+++ b/packages/react-native-audio-api/common/cpp/wrappers/AudioBufferWrapper.cpp
@@ -26,11 +26,6 @@ float *AudioBufferWrapper::getChannelData(int channel) const {
   return audioBuffer_->getChannelData(channel);
 }
 
-void AudioBufferWrapper::setChannelData(int channel, float *data, int length)
-    const {
-  audioBuffer_->setChannelData(channel, data, length);
-}
-
 void AudioBufferWrapper::copyFromChannel(
     float *destination,
     int destinationLength,

--- a/packages/react-native-audio-api/common/cpp/wrappers/AudioBufferWrapper.cpp
+++ b/packages/react-native-audio-api/common/cpp/wrappers/AudioBufferWrapper.cpp
@@ -30,4 +30,22 @@ void AudioBufferWrapper::setChannelData(int channel, float *data, int length)
     const {
   audioBuffer_->setChannelData(channel, data, length);
 }
+
+void AudioBufferWrapper::copyFromChannel(
+    float *destination,
+    int destinationLength,
+    int channelNumber,
+    int startInChannel) const {
+  audioBuffer_->copyFromChannel(
+      destination, destinationLength, channelNumber, startInChannel);
+}
+
+void AudioBufferWrapper::copyToChannel(
+    float *source,
+    int sourceLength,
+    int channelNumber,
+    int startInChannel) const {
+  audioBuffer_->copyToChannel(
+      source, sourceLength, channelNumber, startInChannel);
+}
 } // namespace audioapi

--- a/packages/react-native-audio-api/common/cpp/wrappers/AudioBufferWrapper.h
+++ b/packages/react-native-audio-api/common/cpp/wrappers/AudioBufferWrapper.h
@@ -16,7 +16,6 @@ class AudioBufferWrapper {
   double getDuration() const;
   int getSampleRate() const;
   float *getChannelData(int channel) const;
-  void setChannelData(int channel, float *data, int length) const;
   void copyFromChannel(
       float *destination,
       int destinationLength,

--- a/packages/react-native-audio-api/common/cpp/wrappers/AudioBufferWrapper.h
+++ b/packages/react-native-audio-api/common/cpp/wrappers/AudioBufferWrapper.h
@@ -17,5 +17,15 @@ class AudioBufferWrapper {
   int getSampleRate() const;
   float *getChannelData(int channel) const;
   void setChannelData(int channel, float *data, int length) const;
+  void copyFromChannel(
+      float *destination,
+      int destinationLength,
+      int channelNumber,
+      int startInChannel = 0) const;
+  void copyToChannel(
+      float *source,
+      int sourceLength,
+      int channelNumber,
+      int startInChannel = 0) const;
 };
 } // namespace audioapi

--- a/packages/react-native-audio-api/src/types.ts
+++ b/packages/react-native-audio-api/src/types.ts
@@ -90,14 +90,13 @@ export interface AudioBuffer {
   readonly sampleRate: number;
   readonly numberOfChannels: number;
   getChannelData(channel: number): number[];
-  setChannelData(channel: number, data: number[]): void;
   copyFromChannel(
-    destination: Float32Array,
+    destination: number[],
     channelNumber: number,
     startInChannel: number
   ): void;
   copyToChannel(
-    source: Float32Array,
+    source: number[],
     channelNumber: number,
     startInChannel: number
   ): void;

--- a/packages/react-native-audio-api/src/types.ts
+++ b/packages/react-native-audio-api/src/types.ts
@@ -82,7 +82,7 @@ export interface BiquadFilterNode extends AudioNode {
   type: FilterType;
 }
 
-export type ContextState = 'running' | 'closed';
+export type ContextState = 'running' | 'closed' | 'suspended';
 
 export interface AudioBuffer {
   readonly length: number;
@@ -91,6 +91,16 @@ export interface AudioBuffer {
   readonly numberOfChannels: number;
   getChannelData(channel: number): number[];
   setChannelData(channel: number, data: number[]): void;
+  copyFromChannel(
+    destination: Float32Array,
+    channelNumber: number,
+    startInChannel: number
+  ): void;
+  copyToChannel(
+    source: Float32Array,
+    channelNumber: number,
+    startInChannel: number
+  ): void;
 }
 
 export interface AudioBufferSourceNode extends AudioScheduledSourceNode {


### PR DESCRIPTION
Closes #161 
Closes #156 - modifying by index is impossible cause we have to return js Array

## Introduced changes

- Implemented `copyToChannel()`
- Implemented `copyFromChannel()`
- Removed `setChannelData()` and replaced with `copyToChannel()`

## Checklist

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added/Conducted relevant tests
- [x] Performed self-review of the code