### PR TITLE
fix: base audio context construction + audio player start stop events

### DIFF
--- a/apps/common-app/src/examples/DrumMachine/usePlayer.tsx
+++ b/apps/common-app/src/examples/DrumMachine/usePlayer.tsx
@@ -133,6 +133,10 @@ export default function usePlayer(options: PlayerOptions) {
       playingInstruments.value = getPlayingInstruments();
     }
 
+    return () => {
+      audioContext.close();
+    };
+
     // \/ Shared values are not necessary in deps array
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isPlaying, setup]);

--- a/packages/react-native-audio-api/android/src/main/cpp/AudioPlayer/AudioPlayer.h
+++ b/packages/react-native-audio-api/android/src/main/cpp/AudioPlayer/AudioPlayer.h
@@ -28,6 +28,7 @@ class AudioPlayer : public AudioStreamDataCallback {
   std::function<void(AudioBus*, int)> renderAudio_;
   std::shared_ptr<AudioStream> mStream_;
   std::shared_ptr<AudioBus> mBus_;
+  bool isInitialized_ = false;
 };
 
 } // namespace audioapi

--- a/packages/react-native-audio-api/common/cpp/core/AudioContext.cpp
+++ b/packages/react-native-audio-api/common/cpp/core/AudioContext.cpp
@@ -9,16 +9,13 @@
 
 namespace audioapi {
 
-AudioContext::AudioContext() : BaseAudioContext() {}
+AudioContext::AudioContext() : BaseAudioContext() {
+  audioPlayer_->start();
+}
 
 void AudioContext::close() {
   state_ = ContextState::CLOSED;
-
-  if (audioPlayer_) {
-    audioPlayer_->stop();
-  }
-
-  audioPlayer_.reset();
-  destination_.reset();
+  audioPlayer_->stop();
 }
+
 } // namespace audioapi

--- a/packages/react-native-audio-api/common/cpp/core/AudioDestinationNode.cpp
+++ b/packages/react-native-audio-api/common/cpp/core/AudioDestinationNode.cpp
@@ -24,12 +24,12 @@ double AudioDestinationNode::getCurrentTime() const {
 }
 
 void AudioDestinationNode::renderAudio(AudioBus *destinationBus, int32_t numFrames) {
-  context_->getNodeManager()->preProcessGraph();
-  destinationBus->zero();
-
-  if (!numFrames) {
+  if (!numFrames || !destinationBus || !isInitialized_) {
     return;
   }
+
+  context_->getNodeManager()->preProcessGraph();
+  destinationBus->zero();
 
   AudioBus* processedBus = processAudio(destinationBus, numFrames);
 

--- a/packages/react-native-audio-api/common/cpp/core/BaseAudioContext.cpp
+++ b/packages/react-native-audio-api/common/cpp/core/BaseAudioContext.cpp
@@ -30,9 +30,17 @@ BaseAudioContext::BaseAudioContext() {
   sampleRate_ = audioPlayer_->getSampleRate();
   bufferSizeInFrames_ = audioPlayer_->getBufferSizeInFrames();
 
-  audioPlayer_->start();
   nodeManager_ = std::make_shared<AudioNodeManager>();
   destination_ = std::make_shared<AudioDestinationNode>(this);
+}
+
+BaseAudioContext::~BaseAudioContext() {
+  if (isRunning()) {
+    return;
+  }
+
+  state_ = ContextState::CLOSED;
+  audioPlayer_->stop();
 }
 
 std::string BaseAudioContext::getState() {
@@ -96,7 +104,7 @@ std::shared_ptr<PeriodicWave> BaseAudioContext::createPeriodicWave(
 }
 
 std::function<void(AudioBus *, int)> BaseAudioContext::renderAudio() {
-  if (state_ == ContextState::CLOSED) {
+  if (isClosed()) {
     return [](AudioBus *, int) {};
   }
 
@@ -107,6 +115,14 @@ std::function<void(AudioBus *, int)> BaseAudioContext::renderAudio() {
 
 AudioNodeManager* BaseAudioContext::getNodeManager() {
   return nodeManager_.get();
+}
+
+bool BaseAudioContext::isRunning() const {
+  return state_ == ContextState::RUNNING;
+}
+
+bool BaseAudioContext::isClosed() const {
+  return state_ == ContextState::CLOSED;
 }
 
 std::string BaseAudioContext::toString(ContextState state) {

--- a/packages/react-native-audio-api/common/cpp/core/BaseAudioContext.h
+++ b/packages/react-native-audio-api/common/cpp/core/BaseAudioContext.h
@@ -31,6 +31,7 @@ class IOSAudioPlayer;
 class BaseAudioContext {
  public:
   BaseAudioContext();
+  ~BaseAudioContext();
   std::string getState();
   [[nodiscard]] int getSampleRate() const;
   [[nodiscard]] double getCurrentTime() const;
@@ -54,6 +55,8 @@ class BaseAudioContext {
   std::function<void(AudioBus *, int)> renderAudio();
 
   AudioNodeManager* getNodeManager();
+  bool isRunning() const;
+  bool isClosed() const;
 
  protected:
   static std::string toString(ContextState state);


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## Introduced changes

<!-- A brief description of the changes -->

- Fixes android issues when starting/stopping audio context and player
- Fixes issue with construction and deconstruction of AudioContext and Player

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added/Conducted relevant tests
- [x] Performed self-review of the code
