### PR TITLE
fix: correct buffer lengths on real ios devices

### DIFF
--- a/packages/react-native-audio-api/common/cpp/core/AudioDestinationNode.cpp
+++ b/packages/react-native-audio-api/common/cpp/core/AudioDestinationNode.cpp
@@ -31,6 +31,7 @@ void AudioDestinationNode::renderAudio(
   }
 
   context_->getNodeManager()->preProcessGraph();
+
   destinationBus->zero();
 
   AudioBus *processedBus = processAudio(destinationBus, numFrames);

--- a/packages/react-native-audio-api/common/cpp/core/BaseAudioContext.cpp
+++ b/packages/react-native-audio-api/common/cpp/core/BaseAudioContext.cpp
@@ -120,7 +120,7 @@ std::shared_ptr<AudioBuffer> BaseAudioContext::decodeAudioDataSource(
 #endif
 
 std::function<void(AudioBus *, int)> BaseAudioContext::renderAudio() {
-  if (isClosed()) {
+  if (!isRunning()) {
     return [](AudioBus *, int) {};
   }
 

--- a/packages/react-native-audio-api/ios/AudioPlayer/AudioPlayer.m
+++ b/packages/react-native-audio-api/ios/AudioPlayer/AudioPlayer.m
@@ -62,7 +62,8 @@
   // which is safer to base our internal AudioBus sizes.
   // Buut no documentation => no guarantee :)
   // If something is crackling when it should play silence, start here 📻
-  return (int)(self.audioSession.preferredIOBufferDuration * self.audioSession.sampleRate);
+  double maxBufferDuration = fmax(0.02, fmax(self.audioSession.IOBufferDuration, self.audioSession.preferredIOBufferDuration));
+  return (int)(maxBufferDuration * self.audioSession.sampleRate + 1);
 }
 
 - (void)start


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #228 

## Introduced changes

- Fixes issue with preferredIOSBufferDuration being 0 on real iOS device

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added/Conducted relevant tests
- [x] Performed self-review of the code
