### PR TITLE
Fixes: ASSN, piano minimal sound length, usePlayer timing

### DIFF
--- a/apps/common-app/src/examples/Piano/PianoNote.tsx
+++ b/apps/common-app/src/examples/Piano/PianoNote.tsx
@@ -13,6 +13,7 @@ class PianoNote {
 
   private gain: GainNode | null = null;
   private bufferSource: AudioBufferSourceNode | null = null;
+  private startedAt: number | null = null;
 
   constructor(audioContext: AudioContext, key: Key) {
     this.audioContext = audioContext;
@@ -33,16 +34,13 @@ class PianoNote {
     this.bufferSource.playbackRate.value = playbackRate;
 
     this.gain = this.audioContext.createGain();
-    this.gain.gain.setValueAtTime(0.001, this.audioContext.currentTime);
-    this.gain.gain.exponentialRampToValueAtTime(
-      1,
-      this.audioContext.currentTime + 0.01
-    );
+    this.gain.gain.setValueAtTime(1, this.audioContext.currentTime);
 
     this.bufferSource.connect(this.gain);
     this.gain.connect(this.audioContext.destination);
 
     this.bufferSource.start(tNow);
+    this.startedAt = tNow;
   }
 
   stop() {
@@ -50,10 +48,13 @@ class PianoNote {
       return;
     }
 
-    const tNow = this.audioContext.currentTime;
+    const tNow = Math.max(
+      this.audioContext.currentTime,
+      (this.startedAt ?? 0) + 5.0
+    );
 
-    this.gain.gain.exponentialRampToValueAtTime(0.0001, tNow);
-    this.gain.gain.setValueAtTime(0, tNow + 0.01);
+    this.gain.gain.exponentialRampToValueAtTime(0.0001, tNow + 0.08);
+    this.gain.gain.setValueAtTime(0, tNow + 0.09);
     this.bufferSource.stop(tNow + 0.1);
 
     this.bufferSource = null;

--- a/apps/common-app/src/utils/usePlayer.tsx
+++ b/apps/common-app/src/utils/usePlayer.tsx
@@ -79,7 +79,7 @@ export default function usePlayer(options: PlayerOptions) {
             true
           );
 
-          playNote(r(patternsRef)[i].instrumentName, audioContext.currentTime);
+          playNote(r(patternsRef)[i].instrumentName, nextNoteTime);
         }
       }
 

--- a/packages/audiodocs/docs/fundamentals/making-a-piano-keyboard.mdx
+++ b/packages/audiodocs/docs/fundamentals/making-a-piano-keyboard.mdx
@@ -286,7 +286,7 @@ const onKeyPressOut = (which: KeyName) => {
 
   const { source, envelope, startedAt } = playingNote;
 
-  const tStop = Math.max(audioContext.currentTime, startedAt + 1);
+  const tStop = Math.max(audioContext.currentTime, startedAt + 5);
 
   envelope.gain.exponentialRampToValueAtTime(0.0001, tStop + 0.08);
   envelope.gain.setValueAtTime(0, tStop + 0.09);

--- a/packages/audiodocs/src/examples/SimplePiano/EnvelopesComponent.tsx
+++ b/packages/audiodocs/src/examples/SimplePiano/EnvelopesComponent.tsx
@@ -86,7 +86,7 @@ const SimplePiano: FC = () => {
 
     const { source, envelope, startedAt } = playingNote;
 
-    const tStop = Math.max(audioContext.currentTime, startedAt + 1);
+    const tStop = Math.max(audioContext.currentTime, startedAt + 5);
 
     envelope.gain.exponentialRampToValueAtTime(0.0001, tStop + 0.08);
     envelope.gain.setValueAtTime(0, tStop + 0.09);

--- a/packages/audiodocs/src/examples/SimplePiano/EnvelopesSource.tsx
+++ b/packages/audiodocs/src/examples/SimplePiano/EnvelopesSource.tsx
@@ -87,7 +87,7 @@ const SimplePiano: FC = () => {
 
     const { source, envelope, startedAt } = playingNote;
 
-    const tStop = Math.max(audioContext.currentTime, startedAt + 1);
+    const tStop = Math.max(audioContext.currentTime, startedAt + 5);
 
     envelope.gain.exponentialRampToValueAtTime(0.0001, tStop + 0.08);
     envelope.gain.setValueAtTime(0, tStop + 0.09);

--- a/packages/audiodocs/src/examples/SimplePiano/FinalComponent.tsx
+++ b/packages/audiodocs/src/examples/SimplePiano/FinalComponent.tsx
@@ -116,7 +116,7 @@ const SimplePiano: FC = () => {
       return;
     }
 
-    const tNow = Math.max(aCtx.currentTime, startedAt + 1);
+    const tNow = Math.max(aCtx.currentTime, startedAt + 5.0);
 
     envelope.gain.exponentialRampToValueAtTime(0.0001, tNow + 0.08);
     envelope.gain.setValueAtTime(0, tNow + 0.09);

--- a/packages/audiodocs/src/examples/SimplePiano/FinalSource.tsx
+++ b/packages/audiodocs/src/examples/SimplePiano/FinalSource.tsx
@@ -117,7 +117,7 @@ const SimplePiano: FC = () => {
       return;
     }
 
-    const tNow = Math.max(aCtx.currentTime, startedAt + 1);
+    const tNow = Math.max(aCtx.currentTime, startedAt + 5);
 
     envelope.gain.exponentialRampToValueAtTime(0.0001, tNow + 0.08);
     envelope.gain.setValueAtTime(0, tNow + 0.09);

--- a/packages/react-native-audio-api/common/cpp/core/AudioScheduledSourceNode.cpp
+++ b/packages/react-native-audio-api/common/cpp/core/AudioScheduledSourceNode.cpp
@@ -86,7 +86,7 @@ void AudioScheduledSourceNode::updatePlaybackInfo(
         ? std::max(startFrame, firstFrame) - firstFrame
         : 0;
     nonSilentFramesToProcess =
-        std::min(lastFrame, stopFrame) - startFrame - startOffset;
+        std::min(lastFrame, stopFrame) - startFrame;
     processingBus->zero(0, startOffset);
     return;
   }


### PR DESCRIPTION
Closes #250 

## Introduced changes

- Fixes issue with calculation of `nonSilentFramesToProcess` inside AudioScheduledSourceNode, which was causing size_t overflow for `startOffset > 0` resulting in writing outside of buffers causing various crashes
- [Docs and Example] sets minimal piano key sound duration to 5 seconds (sounds more natural ;))
- usePlayer - use the real timestamp of the note to play instead overwriting it with "render quantum" start

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added/Conducted relevant tests
- [x] Performed self-review of the code
