### PR TITLE
Refacotr/decode audio data removes file prefix

### DIFF
--- a/apps/common-app/src/examples/AudioFile/AudioFile.tsx
+++ b/apps/common-app/src/examples/AudioFile/AudioFile.tsx
@@ -42,7 +42,7 @@ const AudioFile: FC = () => {
         setIsPlaying(false);
 
         setIsLoading(true);
-        await fetchAudioBuffer(result.assets[0].uri.replace('file://', ''));
+        await fetchAudioBuffer(result.assets[0].uri);
         setIsLoading(false);
       }
     } catch (error) {

--- a/apps/common-app/src/examples/AudioVisualizer/AudioVisualizer.tsx
+++ b/apps/common-app/src/examples/AudioVisualizer/AudioVisualizer.tsx
@@ -90,13 +90,10 @@ const AudioVisualizer: React.FC = () => {
       audioBufferRef.current = await FileSystem.downloadAsync(
         URL,
         FileSystem.documentDirectory + 'audio.mp3'
-      )
-        .then(({ uri }) => {
-          return uri.replace('file://', '');
-        })
-        .then((uri) => {
-          return audioContextRef.current!.decodeAudioDataSource(uri);
-        });
+      ).then(({ uri }) => {
+        return audioContextRef.current!.decodeAudioDataSource(uri);
+      });
+
       setIsLoading(false);
     };
 

--- a/apps/common-app/src/examples/Piano/Piano.tsx
+++ b/apps/common-app/src/examples/Piano/Piano.tsx
@@ -30,13 +30,9 @@ const Piano: FC = () => {
       bufferListRef.current[key as KeyName] = await FileSystem.downloadAsync(
         url,
         FileSystem.documentDirectory + key.replace('#', 's') + '.mp3'
-      )
-        .then(({ uri }) => {
-          return uri.replace('file://', '');
-        })
-        .then((uri) => {
-          return audioContextRef.current!.decodeAudioDataSource(uri);
-        });
+      ).then(({ uri }) => {
+        return audioContextRef.current!.decodeAudioDataSource(uri);
+      });
     });
 
     const newNotes: Partial<Record<KeyName, PianoNote>> = {};

--- a/packages/react-native-audio-api/src/core/BaseAudioContext.ts
+++ b/packages/react-native-audio-api/src/core/BaseAudioContext.ts
@@ -101,6 +101,11 @@ export default class BaseAudioContext {
   }
 
   async decodeAudioDataSource(sourcePath: string): Promise<AudioBuffer> {
+    // Remove the file:// prefix if it exists
+    if (sourcePath.startsWith('file://')) {
+      sourcePath = sourcePath.replace('file://', '');
+    }
+
     const buffer = await this.context.decodeAudioDataSource(sourcePath);
 
     return new AudioBuffer(buffer);


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #257 

## Introduced changes

<!-- A brief description of the changes -->

- Added removing `file://` prefix in `decodeAudioDataSource` method on ts side

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added/Conducted relevant tests
- [ ] Performed self-review of the code
