### PR TITLE
Refactor/general context refactoring

### DIFF
--- a/apps/fabric-example/ios/Podfile.lock
+++ b/apps/fabric-example/ios/Podfile.lock
@@ -1656,7 +1656,7 @@ PODS:
     - React-logger (= 0.76.5)
     - React-perflogger (= 0.76.5)
     - React-utils (= 0.76.5)
-  - RNAudioAPI (0.3.2):
+  - RNAudioAPI (0.4.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2152,7 +2152,7 @@ SPEC CHECKSUMS:
   React-utils: f584a494ac233c7857bab176416b0c49cb4037ba
   ReactCodegen: 1f59af46efc9351f27046d90d9ceb5e99385f623
   ReactCommon: 5809a8ee421b7219221a475b78180f8f34b5c5ec
-  RNAudioAPI: 0672a736922266bbb418cb6481d32204e8136988
+  RNAudioAPI: 8a98b4d1149f55f3815919576d50520fbab125f9
   RNGestureHandler: e1dcb274c17ca0680a04d7ff357e35e37c384185
   RNReanimated: 270e2df37d3a18e8270a9c461d9f90a374a97d04
   RNScreens: 351f431ef2a042a1887d4d90e1c1024b8ae9d123

--- a/packages/react-native-audio-api/android/src/main/cpp/core/AudioPlayer.h
+++ b/packages/react-native-audio-api/android/src/main/cpp/core/AudioPlayer.h
@@ -15,7 +15,6 @@ class AudioPlayer : public AudioStreamDataCallback {
   explicit AudioPlayer(const std::function<void(AudioBus *, int)> &renderAudio);
 
   [[nodiscard]] int getSampleRate() const;
-  [[nodiscard]] int getBufferSizeInFrames() const;
   void start();
   void stop();
 

--- a/packages/react-native-audio-api/common/cpp/core/AudioContext.cpp
+++ b/packages/react-native-audio-api/common/cpp/core/AudioContext.cpp
@@ -16,7 +16,6 @@ AudioContext::AudioContext() : BaseAudioContext() {
   audioPlayer_ = std::make_shared<IOSAudioPlayer>(this->renderAudio());
 #endif
   sampleRate_ = audioPlayer_->getSampleRate();
-  bufferSizeInFrames_ = audioPlayer_->getBufferSizeInFrames();
 
   audioPlayer_->start();
 }

--- a/packages/react-native-audio-api/common/cpp/core/AudioContext.cpp
+++ b/packages/react-native-audio-api/common/cpp/core/AudioContext.cpp
@@ -5,16 +5,43 @@
 #endif
 
 #include "AudioContext.h"
+#include "AudioDestinationNode.h"
 
 namespace audioapi {
 
 AudioContext::AudioContext() : BaseAudioContext() {
+#ifdef ANDROID
+  audioPlayer_ = std::make_shared<AudioPlayer>(this->renderAudio());
+#else
+  audioPlayer_ = std::make_shared<IOSAudioPlayer>(this->renderAudio());
+#endif
+  sampleRate_ = audioPlayer_->getSampleRate();
+  bufferSizeInFrames_ = audioPlayer_->getBufferSizeInFrames();
+
   audioPlayer_->start();
+}
+
+AudioContext::~AudioContext() {
+  if (isRunning()) {
+    return;
+  }
+
+  close();
 }
 
 void AudioContext::close() {
   state_ = ContextState::CLOSED;
   audioPlayer_->stop();
+}
+
+std::function<void(AudioBus *, int)> AudioContext::renderAudio() {
+  if (!isRunning()) {
+    return [](AudioBus *, int) {};
+  }
+
+  return [this](AudioBus *data, int frames) {
+    destination_->renderAudio(data, frames);
+  };
 }
 
 } // namespace audioapi

--- a/packages/react-native-audio-api/common/cpp/core/AudioContext.h
+++ b/packages/react-native-audio-api/common/cpp/core/AudioContext.h
@@ -6,11 +6,28 @@
 
 namespace audioapi {
 
+#ifdef ANDROID
+    class AudioPlayer;
+#else
+    class IOSAudioPlayer;
+#endif
+
 class AudioContext : public BaseAudioContext {
  public:
   AudioContext();
+  ~AudioContext() override;
 
   void close();
+
+  std::function<void(AudioBus *, int)> renderAudio();
+
+private:
+
+#ifdef ANDROID
+    std::shared_ptr<AudioPlayer> audioPlayer_;
+#else
+    std::shared_ptr<IOSAudioPlayer> audioPlayer_;
+#endif
 };
 
 } // namespace audioapi

--- a/packages/react-native-audio-api/common/cpp/core/AudioContext.h
+++ b/packages/react-native-audio-api/common/cpp/core/AudioContext.h
@@ -5,11 +5,10 @@
 #include "BaseAudioContext.h"
 
 namespace audioapi {
-
 #ifdef ANDROID
-    class AudioPlayer;
+class AudioPlayer;
 #else
-    class IOSAudioPlayer;
+class IOSAudioPlayer;
 #endif
 
 class AudioContext : public BaseAudioContext {
@@ -21,8 +20,7 @@ class AudioContext : public BaseAudioContext {
 
   std::function<void(AudioBus *, int)> renderAudio();
 
-private:
-
+ private:
 #ifdef ANDROID
     std::shared_ptr<AudioPlayer> audioPlayer_;
 #else

--- a/packages/react-native-audio-api/common/cpp/core/AudioNode.cpp
+++ b/packages/react-native-audio-api/common/cpp/core/AudioNode.cpp
@@ -8,10 +8,8 @@
 namespace audioapi {
 
 AudioNode::AudioNode(BaseAudioContext *context) : context_(context) {
-  audioBus_ = std::make_shared<AudioBus>(
-      context->getSampleRate(),
-      context->getBufferSizeInFrames(),
-      channelCount_);
+  audioBus_ =
+      std::make_shared<AudioBus>(context->getSampleRate(), 4360, channelCount_);
 }
 
 AudioNode::~AudioNode() {

--- a/packages/react-native-audio-api/common/cpp/core/AudioNode.cpp
+++ b/packages/react-native-audio-api/common/cpp/core/AudioNode.cpp
@@ -8,8 +8,8 @@
 namespace audioapi {
 
 AudioNode::AudioNode(BaseAudioContext *context) : context_(context) {
-  audioBus_ =
-      std::make_shared<AudioBus>(context->getSampleRate(), 4360, channelCount_);
+  audioBus_ = std::make_shared<AudioBus>(
+      context->getSampleRate(), RENDER_QUANTUM_SIZE, channelCount_);
 }
 
 AudioNode::~AudioNode() {

--- a/packages/react-native-audio-api/common/cpp/core/AudioNode.cpp
+++ b/packages/react-native-audio-api/common/cpp/core/AudioNode.cpp
@@ -205,6 +205,10 @@ void AudioNode::onInputDisabled() {
 }
 
 void AudioNode::onInputConnected(AudioNode *node) {
+  if (!isInitialized_) {
+    return;
+  }
+
   inputNodes_.push_back(node);
 
   if (node->isEnabled()) {
@@ -213,6 +217,10 @@ void AudioNode::onInputConnected(AudioNode *node) {
 }
 
 void AudioNode::onInputDisconnected(AudioNode *node) {
+  if (!isInitialized_) {
+    return;
+  }
+
   auto position = std::find(inputNodes_.begin(), inputNodes_.end(), node);
 
   if (position != inputNodes_.end()) {

--- a/packages/react-native-audio-api/common/cpp/core/BaseAudioContext.cpp
+++ b/packages/react-native-audio-api/common/cpp/core/BaseAudioContext.cpp
@@ -1,9 +1,3 @@
-#ifdef ANDROID
-#include "AudioPlayer.h"
-#else
-#include "IOSAudioPlayer.h"
-#endif
-
 #include "BaseAudioContext.h"
 
 #include "AnalyserNode.h"
@@ -22,29 +16,13 @@
 
 namespace audioapi {
 
-BaseAudioContext::BaseAudioContext() {
-#ifdef ANDROID
-  audioPlayer_ = std::make_shared<AudioPlayer>(this->renderAudio());
-#else
-  audioPlayer_ = std::make_shared<IOSAudioPlayer>(this->renderAudio());
-#endif
-
-  audioDecoder_ = std::make_shared<AudioDecoder>(audioPlayer_->getSampleRate());
-
-  sampleRate_ = audioPlayer_->getSampleRate();
-  bufferSizeInFrames_ = audioPlayer_->getBufferSizeInFrames();
+BaseAudioContext::BaseAudioContext()
+    : sampleRate_(DEFAULT_SAMPLE_RATE),
+      bufferSizeInFrames_(RENDER_QUANTUM_SIZE) {
+  audioDecoder_ = std::make_shared<AudioDecoder>(sampleRate_);
 
   nodeManager_ = std::make_shared<AudioNodeManager>();
   destination_ = std::make_shared<AudioDestinationNode>(this);
-}
-
-BaseAudioContext::~BaseAudioContext() {
-  if (isRunning()) {
-    return;
-  }
-
-  state_ = ContextState::CLOSED;
-  audioPlayer_->stop();
 }
 
 std::string BaseAudioContext::getState() {
@@ -115,16 +93,6 @@ std::shared_ptr<AudioBuffer> BaseAudioContext::decodeAudioDataSource(
     const std::string &path) {
   auto audioBus = audioDecoder_->decodeWithFilePath(path);
   return std::make_shared<AudioBuffer>(audioBus);
-}
-
-std::function<void(AudioBus *, int)> BaseAudioContext::renderAudio() {
-  if (!isRunning()) {
-    return [](AudioBus *, int) {};
-  }
-
-  return [this](AudioBus *data, int frames) {
-    destination_->renderAudio(data, frames);
-  };
 }
 
 AudioNodeManager *BaseAudioContext::getNodeManager() {

--- a/packages/react-native-audio-api/common/cpp/core/BaseAudioContext.cpp
+++ b/packages/react-native-audio-api/common/cpp/core/BaseAudioContext.cpp
@@ -16,9 +16,7 @@
 
 namespace audioapi {
 
-BaseAudioContext::BaseAudioContext()
-    : sampleRate_(DEFAULT_SAMPLE_RATE),
-      bufferSizeInFrames_(RENDER_QUANTUM_SIZE) {
+BaseAudioContext::BaseAudioContext() : sampleRate_(DEFAULT_SAMPLE_RATE) {
   audioDecoder_ = std::make_shared<AudioDecoder>(sampleRate_);
 
   nodeManager_ = std::make_shared<AudioNodeManager>();
@@ -31,10 +29,6 @@ std::string BaseAudioContext::getState() {
 
 int BaseAudioContext::getSampleRate() const {
   return sampleRate_;
-}
-
-int BaseAudioContext::getBufferSizeInFrames() const {
-  return bufferSizeInFrames_;
 }
 
 std::size_t BaseAudioContext::getCurrentSampleFrame() const {

--- a/packages/react-native-audio-api/common/cpp/core/BaseAudioContext.h
+++ b/packages/react-native-audio-api/common/cpp/core/BaseAudioContext.h
@@ -24,16 +24,10 @@ class AudioBufferSourceNode;
 class AudioDecoder;
 class AnalyserNode;
 
-#ifdef ANDROID
-class AudioPlayer;
-#else
-class IOSAudioPlayer;
-#endif
-
 class BaseAudioContext {
  public:
   BaseAudioContext();
-  ~BaseAudioContext();
+  virtual ~BaseAudioContext() = default;
 
   std::string getState();
   [[nodiscard]] int getSampleRate() const;
@@ -58,7 +52,6 @@ class BaseAudioContext {
 
   std::shared_ptr<AudioBuffer> decodeAudioDataSource(const std::string &path);
   std::shared_ptr<PeriodicWave> getBasicWaveForm(OscillatorType type);
-  std::function<void(AudioBus *, int)> renderAudio();
   AudioNodeManager *getNodeManager();
   [[nodiscard]] bool isRunning() const;
   [[nodiscard]] bool isClosed() const;
@@ -67,12 +60,6 @@ class BaseAudioContext {
   static std::string toString(ContextState state);
   std::shared_ptr<AudioDestinationNode> destination_;
   std::shared_ptr<AudioDecoder> audioDecoder_;
-
-#ifdef ANDROID
-  std::shared_ptr<AudioPlayer> audioPlayer_;
-#else
-  std::shared_ptr<IOSAudioPlayer> audioPlayer_;
-#endif
 
   int sampleRate_;
   int bufferSizeInFrames_;

--- a/packages/react-native-audio-api/common/cpp/core/BaseAudioContext.h
+++ b/packages/react-native-audio-api/common/cpp/core/BaseAudioContext.h
@@ -32,7 +32,6 @@ class BaseAudioContext {
   std::string getState();
   [[nodiscard]] int getSampleRate() const;
   [[nodiscard]] double getCurrentTime() const;
-  [[nodiscard]] int getBufferSizeInFrames() const;
   [[nodiscard]] std::size_t getCurrentSampleFrame() const;
   std::shared_ptr<AudioDestinationNode> getDestination();
 
@@ -62,7 +61,6 @@ class BaseAudioContext {
   std::shared_ptr<AudioDecoder> audioDecoder_;
 
   int sampleRate_;
-  int bufferSizeInFrames_;
   ContextState state_ = ContextState::RUNNING;
   std::shared_ptr<AudioNodeManager> nodeManager_;
 

--- a/packages/react-native-audio-api/common/cpp/core/Constants.h
+++ b/packages/react-native-audio-api/common/cpp/core/Constants.h
@@ -6,13 +6,14 @@
 // https://webaudio.github.io/web-audio-api/
 
 namespace audioapi {
-constexpr int SAMPLE_RATE = 48000;
+constexpr int DEFAULT_SAMPLE_RATE = 48000;
+constexpr int RENDER_QUANTUM_SIZE = 128;
 constexpr int CHANNEL_COUNT = 2;
 
 constexpr float MOST_POSITIVE_SINGLE_FLOAT = static_cast<float>(std::numeric_limits<float>::max());
 constexpr float MOST_NEGATIVE_SINGLE_FLOAT = static_cast<float>(std::numeric_limits<float>::lowest());
 
-constexpr float NYQUIST_FREQUENCY = SAMPLE_RATE / 2.0;
+constexpr float NYQUIST_FREQUENCY = DEFAULT_SAMPLE_RATE / 2.0;
 static float MAX_DETUNE = 1200 * std::log2(MOST_POSITIVE_SINGLE_FLOAT);
 constexpr float MAX_GAIN = MOST_POSITIVE_SINGLE_FLOAT;
 constexpr float MAX_PAN = 1.0;

--- a/packages/react-native-audio-api/ios/core/AudioPlayer.h
+++ b/packages/react-native-audio-api/ios/core/AudioPlayer.h
@@ -17,8 +17,6 @@ typedef void (^RenderAudioBlock)(AudioBufferList *outputBuffer, int numFrames);
 
 - (int)getSampleRate;
 
-- (int)getBufferSizeInFrames;
-
 - (void)start;
 
 - (void)stop;

--- a/packages/react-native-audio-api/ios/core/AudioPlayer.m
+++ b/packages/react-native-audio-api/ios/core/AudioPlayer.m
@@ -52,21 +52,6 @@
   return [self.audioSession sampleRate];
 }
 
-- (int)getBufferSizeInFrames
-{
-  // Note: might be important in the future.
-  // For some reason audioSession.IOBufferDuration is always 0.01, which for sample rate of 48k
-  // gives exactly 480 frames, while at the same time frameCount requested by AVAudioSourceEngine
-  // might vary f.e. between 555-560.
-  // preferredIOBufferDuration seems to be double the value (resulting in 960 frames),
-  // which is safer to base our internal AudioBus sizes.
-  // Buut no documentation => no guarantee :)
-  // If something is crackling when it should play silence, start here 📻
-  double maxBufferDuration =
-      fmax(0.02, fmax(self.audioSession.IOBufferDuration, self.audioSession.preferredIOBufferDuration));
-  return (int)(maxBufferDuration * self.audioSession.sampleRate + 1);
-}
-
 - (void)start
 {
   [self.audioEngine attachNode:self.sourceNode];

--- a/packages/react-native-audio-api/ios/core/IOSAudioPlayer.h
+++ b/packages/react-native-audio-api/ios/core/IOSAudioPlayer.h
@@ -25,7 +25,6 @@ class IOSAudioPlayer {
   ~IOSAudioPlayer();
 
   int getSampleRate() const;
-  int getBufferSizeInFrames() const;
 
   void start();
   void stop();

--- a/packages/react-native-audio-api/ios/core/IOSAudioPlayer.mm
+++ b/packages/react-native-audio-api/ios/core/IOSAudioPlayer.mm
@@ -10,18 +10,30 @@ namespace audioapi {
 IOSAudioPlayer::IOSAudioPlayer(const std::function<void(AudioBus *, int)> &renderAudio)
     : renderAudio_(renderAudio), audioBus_(0)
 {
+  audioBus_ = new AudioBus(getSampleRate(), RENDER_QUANTUM_SIZE, CHANNEL_COUNT);
+
   RenderAudioBlock renderAudioBlock = ^(AudioBufferList *outputData, int numFrames) {
-    renderAudio_(audioBus_, numFrames);
+    int processedFrames = 0;
 
-    for (int i = 0; i < outputData->mNumberBuffers; i += 1) {
-      float *outputBuffer = (float *)outputData->mBuffers[i].mData;
+    while (processedFrames < numFrames) {
+      int framesToProcess = std::min(numFrames - processedFrames, RENDER_QUANTUM_SIZE);
+      renderAudio_(audioBus_, framesToProcess);
 
-      memcpy(outputBuffer, audioBus_->getChannel(i)->getData(), sizeof(float) * numFrames);
+      // TODO: optimize this with SIMD?
+      for (int channel = 0; channel < CHANNEL_COUNT; channel += 1) {
+        float *outputChannel = (float *)outputData->mBuffers[channel].mData;
+        auto *inputChannel = audioBus_->getChannel(channel)->getData();
+
+        for (int i = 0; i < framesToProcess; i++) {
+          outputChannel[processedFrames + i] = inputChannel[i];
+        }
+      }
+
+      processedFrames += framesToProcess;
     }
   };
 
   audioPlayer_ = [[AudioPlayer alloc] initWithRenderAudioBlock:renderAudioBlock];
-  audioBus_ = new AudioBus(getSampleRate(), getBufferSizeInFrames(), CHANNEL_COUNT);
 }
 
 IOSAudioPlayer::~IOSAudioPlayer()
@@ -48,11 +60,6 @@ void IOSAudioPlayer::stop()
 int IOSAudioPlayer::getSampleRate() const
 {
   return [audioPlayer_ getSampleRate];
-}
-
-int IOSAudioPlayer::getBufferSizeInFrames() const
-{
-  return [audioPlayer_ getBufferSizeInFrames];
 }
 
 } // namespace audioapi


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #264

## Introduced changes

<!-- A brief description of the changes -->

- Moved `AudioPlayer` property to `AudioContext`
- Refactored `renderAudio` function calling by `AudioPlayer`. Currently `renderAudio` renders maximum `RENDER_QUANTUM_SIZE` of frames, so most of `AudioPlayer` audio requests consist of more then one call of `renderAudio`.

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added/Conducted relevant tests
- [ ] Performed self-review of the code
