### PR TITLE
Feat/audio buffer source node/override start method

### DIFF
--- a/apps/common-app/src/examples/AudioVisualizer/AudioVisualizer.tsx
+++ b/apps/common-app/src/examples/AudioVisualizer/AudioVisualizer.tsx
@@ -24,6 +24,9 @@ const AudioVisualizer: React.FC = () => {
   const [times, setTimes] = useState<number[]>(new Array(FFT_SIZE).fill(127));
   const [freqs, setFreqs] = useState<number[]>(new Array(FFT_SIZE / 2).fill(0));
 
+  const [startTime, setStartTime] = useState(0);
+  const [offset, setOffset] = useState(0);
+
   const audioContextRef = useRef<AudioContext | null>(null);
   const analyserRef = useRef<AnalyserNode | null>(null);
   const bufferSourceRef = useRef<AudioBufferSourceNode | null>(null);
@@ -31,7 +34,9 @@ const AudioVisualizer: React.FC = () => {
 
   const handlePlayPause = () => {
     if (isPlaying) {
-      bufferSourceRef.current?.stop();
+      const stopTime = audioContextRef.current!.currentTime;
+      bufferSourceRef.current?.stop(stopTime);
+      setOffset((prev) => prev + stopTime - startTime);
     } else {
       if (!audioContextRef.current || !analyserRef.current) {
         return;
@@ -41,7 +46,8 @@ const AudioVisualizer: React.FC = () => {
       bufferSourceRef.current.buffer = audioBufferRef.current;
       bufferSourceRef.current.connect(analyserRef.current);
 
-      bufferSourceRef.current.start();
+      setStartTime(audioContextRef.current.currentTime);
+      bufferSourceRef.current.start(startTime, offset);
 
       requestAnimationFrame(draw);
     }

--- a/docs/web-audio-coverage.md
+++ b/docs/web-audio-coverage.md
@@ -7,13 +7,16 @@ Some of the noticeable implementation details that are still in progress or not 
 - Support of different number of channels (current approach in most of the audio-graph nodes assumes working with two channel audio)
 - Multi-input for each node and input mixing (Although specification suggests that most of the nodes can cave only one input or output, common use-cases proves otherwise). Only node that mixes multiple inputs is `DestinationNode`.
 
-## ✅ Completed (**11** out of 32)
+## ✅ Completed (**12** out of 32)
 
 <details>
  <summary><b>AnalyserNode</b></summary>
 </details>
 <details>
   <summary><b>AudioBuffer</b></summary>
+</details>
+<details>
+  <summary><b>AudioBufferSourceNode</b></summary>
 </details>
 <details>
  <summary><b>AudioDestinationNode</b></summary>
@@ -43,7 +46,7 @@ Some of the noticeable implementation details that are still in progress or not 
  <summary><b>StereoPannerNode</b></summary>
 </details>
 
-## 🚧 In Progress (**3** out of 32)
+## 🚧 In Progress (**2** out of 32)
 
 <details>
   <summary><b>AudioContext</b></summary>
@@ -62,25 +65,6 @@ Some of the noticeable implementation details that are still in progress or not 
 | 🔘 resume                       | ❌    |
 | 🔘 setSinkId                    | ❌    |
 | 🔘 suspend                      | ❌    |
-
-</div>
-
-</details>
-
-<details>
-  <summary><b>AudioBufferSourceNode</b></summary>
-
-<div style="padding: 16px; padding-left: 42px;">
-
-| Property 🔹/ Method 🔘 | state |
-| ---------------------- | ----- |
-| 🔹 buffer              | ✅    |
-| 🔹 detune              | ✅    |
-| 🔹 loop                | ✅    |
-| 🔹 loopStart           | ✅    |
-| 🔹 loopEnd             | ✅    |
-| 🔹 playBackRate        | ✅    |
-| 🔘 start(overridden)   | ❌    |
 
 </div>
 

--- a/packages/react-native-audio-api/common/cpp/HostObjects/AudioBufferSourceNodeHostObject.h
+++ b/packages/react-native-audio-api/common/cpp/HostObjects/AudioBufferSourceNodeHostObject.h
@@ -28,6 +28,12 @@ class AudioBufferSourceNodeHostObject
     addSetters(
         JSI_EXPORT_PROPERTY_SETTER(AudioBufferSourceNodeHostObject, loop),
         JSI_EXPORT_PROPERTY_SETTER(AudioBufferSourceNodeHostObject, buffer));
+
+    // start method is overridden in this class
+    functions_->erase("start");
+
+    addFunctions(
+        JSI_EXPORT_FUNCTION(AudioBufferSourceNodeHostObject, start));
   }
 
   JSI_PROPERTY_GETTER(loop) {
@@ -110,6 +116,18 @@ class AudioBufferSourceNodeHostObject
     auto audioBufferSourceNode =
         std::static_pointer_cast<AudioBufferSourceNode>(node_);
     audioBufferSourceNode->setLoopEnd(value.getNumber());
+  }
+
+  JSI_HOST_FUNCTION(start) {
+    auto when = args[0].getNumber();
+    auto offset = args[1].getNumber();
+    auto duration = args[2].getNumber();
+
+    auto audioBufferSourceNode =
+      std::static_pointer_cast<AudioBufferSourceNode>(node_);
+    audioBufferSourceNode->start(when, offset, duration);
+
+    return jsi::Value::undefined();
   }
 };
 

--- a/packages/react-native-audio-api/common/cpp/HostObjects/AudioScheduledSourceNodeHostObject.h
+++ b/packages/react-native-audio-api/common/cpp/HostObjects/AudioScheduledSourceNodeHostObject.h
@@ -20,10 +20,10 @@ class AudioScheduledSourceNodeHostObject : public AudioNodeHostObject {
   }
 
   JSI_HOST_FUNCTION(start) {
-    auto time = args[0].getNumber();
+    auto when = args[0].getNumber();
     auto audioScheduleSourceNode =
         std::static_pointer_cast<AudioScheduledSourceNode>(node_);
-    audioScheduleSourceNode->start(time);
+    audioScheduleSourceNode->start(when);
     return jsi::Value::undefined();
   }
 

--- a/packages/react-native-audio-api/common/cpp/core/AudioBuffer.cpp
+++ b/packages/react-native-audio-api/common/cpp/core/AudioBuffer.cpp
@@ -27,8 +27,8 @@ float AudioBuffer::getSampleRate() const {
   return bus_->getSampleRate();
 }
 
-float AudioBuffer::getDuration() const {
-  return static_cast<float>(getLength()) / getSampleRate();
+double AudioBuffer::getDuration() const {
+  return static_cast<double>(getLength()) / getSampleRate();
 }
 
 float *AudioBuffer::getChannelData(int channel) const {

--- a/packages/react-native-audio-api/common/cpp/core/AudioBuffer.h
+++ b/packages/react-native-audio-api/common/cpp/core/AudioBuffer.h
@@ -17,7 +17,7 @@ class AudioBuffer : public std::enable_shared_from_this<AudioBuffer> {
 
   [[nodiscard]] size_t getLength() const;
   [[nodiscard]] float getSampleRate() const;
-  [[nodiscard]] float getDuration() const;
+  [[nodiscard]] double getDuration() const;
 
   [[nodiscard]] int getNumberOfChannels() const;
   [[nodiscard]] float *getChannelData(int channel) const;

--- a/packages/react-native-audio-api/common/cpp/core/AudioBufferSourceNode.cpp
+++ b/packages/react-native-audio-api/common/cpp/core/AudioBufferSourceNode.cpp
@@ -80,6 +80,19 @@ void AudioBufferSourceNode::setBuffer(
   alignedBus_->sum(buffer_->bus_.get());
 }
 
+void AudioBufferSourceNode::start(double when, double offset, double duration) {
+  AudioScheduledSourceNode::start(when);
+
+  offset = std::min(offset, buffer_->getDuration());
+  if (loop_) {
+    offset = std::min(offset, loopEnd_);
+  }
+
+  vReadIndex_ = static_cast<double>(buffer_->getSampleRate() * offset);
+
+  AudioScheduledSourceNode::stop(when + duration);
+}
+
 void AudioBufferSourceNode::processNode(
     AudioBus *processingBus,
     int framesToProcess) {

--- a/packages/react-native-audio-api/common/cpp/core/AudioBufferSourceNode.h
+++ b/packages/react-native-audio-api/common/cpp/core/AudioBufferSourceNode.h
@@ -18,17 +18,16 @@ class AudioBufferSourceNode : public AudioScheduledSourceNode {
   [[nodiscard]] bool getLoop() const;
   [[nodiscard]] double getLoopStart() const;
   [[nodiscard]] double getLoopEnd() const;
-
   [[nodiscard]] std::shared_ptr<AudioParam> getDetuneParam() const;
   [[nodiscard]] std::shared_ptr<AudioParam> getPlaybackRateParam() const;
-
   [[nodiscard]] std::shared_ptr<AudioBuffer> getBuffer() const;
 
   void setLoop(bool loop);
   void setLoopStart(double loopStart);
   void setLoopEnd(double loopEnd);
-
   void setBuffer(const std::shared_ptr<AudioBuffer> &buffer);
+
+  void start(double when, double offset, double duration);
 
  protected:
   void processNode(AudioBus *processingBus, int framesToProcess) override;

--- a/packages/react-native-audio-api/common/cpp/core/AudioScheduledSourceNode.cpp
+++ b/packages/react-native-audio-api/common/cpp/core/AudioScheduledSourceNode.cpp
@@ -15,13 +15,13 @@ AudioScheduledSourceNode::AudioScheduledSourceNode(BaseAudioContext *context)
   numberOfInputs_ = 0;
 }
 
-void AudioScheduledSourceNode::start(double time) {
+void AudioScheduledSourceNode::start(double when) {
   playbackState_ = PlaybackState::SCHEDULED;
-  startTime_ = time;
+  startTime_ = when;
 }
 
-void AudioScheduledSourceNode::stop(double time) {
-  stopTime_ = time;
+void AudioScheduledSourceNode::stop(double when) {
+  stopTime_ = when;
 }
 
 bool AudioScheduledSourceNode::isUnscheduled() {

--- a/packages/react-native-audio-api/common/cpp/core/AudioScheduledSourceNode.h
+++ b/packages/react-native-audio-api/common/cpp/core/AudioScheduledSourceNode.h
@@ -19,8 +19,8 @@ class AudioScheduledSourceNode : public AudioNode {
   enum class PlaybackState { UNSCHEDULED, SCHEDULED, PLAYING, FINISHED };
   explicit AudioScheduledSourceNode(BaseAudioContext *context);
 
-  void start(double time);
-  void stop(double time);
+  void start(double when);
+  void stop(double when);
 
   bool isUnscheduled();
   bool isScheduled();

--- a/packages/react-native-audio-api/src/core/AudioBufferSourceNode.ts
+++ b/packages/react-native-audio-api/src/core/AudioBufferSourceNode.ts
@@ -3,6 +3,7 @@ import AudioScheduledSourceNode from './AudioScheduledSourceNode';
 import BaseAudioContext from './BaseAudioContext';
 import AudioBuffer from './AudioBuffer';
 import AudioParam from './AudioParam';
+import { InvalidStateError, RangeError } from '../errors';
 
 export default class AudioBufferSourceNode extends AudioScheduledSourceNode {
   readonly playbackRate: AudioParam;
@@ -54,5 +55,42 @@ export default class AudioBufferSourceNode extends AudioScheduledSourceNode {
 
   public set loopEnd(value: number) {
     (this.node as IAudioBufferSourceNode).loopEnd = value;
+  }
+
+  public start(when: number = 0, offset: number = 0, duration?: number): void {
+    if (when < 0) {
+      throw new RangeError(
+        `when must be a finite non-negative number: ${when}`
+      );
+    }
+
+    if (offset < 0) {
+      throw new RangeError(
+        `offset must be a finite non-negative number: ${when}`
+      );
+    }
+
+    if (duration && duration < 0) {
+      throw new RangeError(
+        `duration must be a finite non-negative number: ${when}`
+      );
+    }
+
+    if (this.hasBeenStarted) {
+      throw new InvalidStateError('Cannot call start more than once');
+    }
+
+    this.hasBeenStarted = true;
+
+    if (duration) {
+      (this.node as IAudioBufferSourceNode).start(when, offset, duration);
+      return;
+    }
+
+    (this.node as IAudioBufferSourceNode).start(
+      when,
+      offset,
+      this.buffer!.duration
+    );
   }
 }

--- a/packages/react-native-audio-api/src/core/AudioScheduledSourceNode.ts
+++ b/packages/react-native-audio-api/src/core/AudioScheduledSourceNode.ts
@@ -3,12 +3,12 @@ import AudioNode from './AudioNode';
 import { InvalidStateError, RangeError } from '../errors';
 
 export default class AudioScheduledSourceNode extends AudioNode {
-  private hasBeenStarted: boolean = false;
+  protected hasBeenStarted: boolean = false;
 
   public start(when: number = 0): void {
     if (when < 0) {
       throw new RangeError(
-        `Time must be a finite non-negative number: ${when}`
+        `when must be a finite non-negative number: ${when}`
       );
     }
 
@@ -23,7 +23,7 @@ export default class AudioScheduledSourceNode extends AudioNode {
   public stop(when: number = 0): void {
     if (when < 0) {
       throw new RangeError(
-        `Time must be a finite non-negative number: ${when}`
+        `when must be a finite non-negative number: ${when}`
       );
     }
 

--- a/packages/react-native-audio-api/src/index.ts
+++ b/packages/react-native-audio-api/src/index.ts
@@ -257,6 +257,14 @@ export class AudioBufferSourceNode extends AudioScheduledSourceNode {
   public set loopEnd(value: number) {
     (this.node as globalThis.AudioBufferSourceNode).loopEnd = value;
   }
+
+  public start(when?: number, offset?: number, duration?: number): void {
+    (this.node as globalThis.AudioBufferSourceNode).start(
+      when,
+      offset,
+      duration
+    );
+  }
 }
 
 export class AudioDestinationNode extends AudioNode {}

--- a/packages/react-native-audio-api/src/interfaces.ts
+++ b/packages/react-native-audio-api/src/interfaces.ts
@@ -73,8 +73,8 @@ export interface IBiquadFilterNode extends IAudioNode {
 export interface IAudioDestinationNode extends IAudioNode {}
 
 export interface IAudioScheduledSourceNode extends IAudioNode {
-  start: (time: number) => void;
-  stop: (time: number) => void;
+  start(when?: number): void;
+  stop: (when: number) => void;
 }
 
 export interface IOscillatorNode extends IAudioScheduledSourceNode {
@@ -90,9 +90,10 @@ export interface IAudioBufferSourceNode extends IAudioScheduledSourceNode {
   loop: boolean;
   loopStart: number;
   loopEnd: number;
-
   detune: IAudioParam;
   playbackRate: IAudioParam;
+
+  start: (when?: number, offset?: number, duration?: number) => void;
 }
 
 export interface IAudioBuffer {


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #282
Closes #163 

## Introduced changes

<!-- A brief description of the changes -->

- Implemented `AudioBufferSourceNode's` `start(when, offset, duration)` method. Currently it is possible to call classic `pause` on buffer playback.

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added/Conducted relevant tests
- [x] Performed self-review of the code
