### PR TITLE
fix: add lock mechanism to buffer changes in ABSN

### DIFF
--- a/packages/react-native-audio-api/common/cpp/core/AudioBufferSourceNode.h
+++ b/packages/react-native-audio-api/common/cpp/core/AudioBufferSourceNode.h
@@ -30,6 +30,7 @@ class AudioBufferSourceNode : public AudioScheduledSourceNode {
   void start(double when, double offset, double duration = -1);
 
  protected:
+  std::mutex &getBufferLock();
   void processNode(AudioBus *processingBus, int framesToProcess) override;
 
  private:
@@ -37,6 +38,7 @@ class AudioBufferSourceNode : public AudioScheduledSourceNode {
   bool loop_;
   double loopStart_;
   double loopEnd_;
+  std::mutex bufferLock_;
 
   // playback rate aka pitch change params
   std::shared_ptr<AudioParam> detuneParam_;


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## Introduced changes

<!-- A brief description of the changes -->

- Adds Lock mechanism to read/write from buffer in audio buffer source node to avoid reading from incompletely copied buffer, which might lead to nullptrs

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [x] Added/Conducted relevant tests
- [x] Performed self-review of the code
- [ ] Updated Web Audio API coverage
- [ ] Added support for web
