### PR TITLE
feat: added resume and suspend methods o docs and updated methods to …

### DIFF
--- a/packages/audiodocs/docs/core/audio-context.mdx
+++ b/packages/audiodocs/docs/core/audio-context.mdx
@@ -26,3 +26,16 @@ It is responsible for supervising and managing audio-processing graph.
 Above method lets you close the audio context, releasing any system audio resources that it uses.
 
 #### Returns `Promise<undefined>`.
+
+### `suspend`
+
+Above method lets you suspend time progression in the audio context.
+It is useful when your application will not use audio for a while.
+
+#### Returns `Promise<undefined>`.
+
+### `resume`
+
+Above method lets resume time progression in audio context that previously has been suspended.
+
+#### Returns `Promise<undefined>`.

--- a/packages/audiodocs/yarn.lock
+++ b/packages/audiodocs/yarn.lock
@@ -10039,10 +10039,10 @@ react-loadable-ssr-addon-v5-slorber@^1.0.1:
     "@types/react" "*"
     prop-types "^15.6.2"
 
-react-native-audio-api@0.4.9:
-  version "0.4.9"
-  resolved "https://registry.yarnpkg.com/react-native-audio-api/-/react-native-audio-api-0.4.9.tgz#c049f60330187877110e33e0298d2c8177bee0eb"
-  integrity sha512-SwfwrvY3Xia25v40sPOgjpMXcAODQn0WQbPoVkHvU7um8FkEf1RpUuDfpY3kVDxGr+Qhopx/gkY96dPhnKwR3w==
+react-native-audio-api@0.4.11:
+  version "0.4.11"
+  resolved "https://registry.yarnpkg.com/react-native-audio-api/-/react-native-audio-api-0.4.11.tgz#e66737e1cf815405c4ffed245eb9fae05ebd802a"
+  integrity sha512-5vsUBEAyrR7kgNV2ezWz/ZppJlZttx3vo3zVSHMj4Vv2850n1fNKAiEW22FATs6PIkjIRWopPJNHmE9prQC9/A==
 
 react-native-codegen@^0.71.6:
   version "0.71.6"

--- a/packages/react-native-audio-api/common/cpp/audioapi/HostObjects/AudioContextHostObject.h
+++ b/packages/react-native-audio-api/common/cpp/audioapi/HostObjects/AudioContextHostObject.h
@@ -42,10 +42,15 @@ class AudioContextHostObject : public BaseAudioContextHostObject {
     auto promise = promiseVendor_->createPromise([this](std::shared_ptr<Promise> promise) {
       std::thread([this, promise = std::move(promise)]() {
           auto audioContext = std::static_pointer_cast<AudioContext>(context_);
-          audioContext->resume();
+          auto result = audioContext->resume();
+
+          if (!result) {
+            promise->reject("Failed to resume audio context, because it is already closed.");
+            return;
+          }
 
           promise->resolve([](jsi::Runtime &runtime) {
-              return jsi::Value::undefined();
+            return jsi::Value::undefined();
           });
       }).detach();
     });
@@ -57,10 +62,15 @@ class AudioContextHostObject : public BaseAudioContextHostObject {
     auto promise = promiseVendor_->createPromise([this](std::shared_ptr<Promise> promise) {
       std::thread([this, promise = std::move(promise)]() {
           auto audioContext = std::static_pointer_cast<AudioContext>(context_);
-          audioContext->suspend();
+          auto result = audioContext->suspend();
+
+          if (!result) {
+            promise->reject("Failed to resume audio context, because it is already closed.");
+            return;
+          }
 
           promise->resolve([](jsi::Runtime &runtime) {
-              return jsi::Value::undefined();
+            return jsi::Value::undefined();
           });
       }).detach();
     });

--- a/packages/react-native-audio-api/common/cpp/audioapi/HostObjects/BaseAudioContextHostObject.h
+++ b/packages/react-native-audio-api/common/cpp/audioapi/HostObjects/BaseAudioContextHostObject.h
@@ -156,7 +156,7 @@ class BaseAudioContextHostObject : public JsiHostObject {
         auto audioBufferHostObject = std::make_shared<AudioBufferHostObject>(results);
 
         if (!results) {
-          promise->reject("Failed to decode audio data source");
+          promise->reject("Failed to decode audio data source.");
           return;
         }
 

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/AudioContext.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/AudioContext.cpp
@@ -39,23 +39,33 @@ AudioContext::~AudioContext() {
   if (!isClosed()) {
     close();
   }
-
-  nodeManager_->cleanup();
 }
 
 void AudioContext::close() {
   state_ = ContextState::CLOSED;
   audioPlayer_->stop();
+
+  nodeManager_->cleanup();
 }
 
-void AudioContext::resume() {
+bool AudioContext::resume() {
+  if (isClosed()) {
+    return false;
+  }
+
   state_ = ContextState::RUNNING;
   audioPlayer_->resume();
+  return true;
 }
 
-void AudioContext::suspend() {
+bool AudioContext::suspend() {
+  if (isClosed()) {
+    return false;
+  }
+
   state_ = ContextState::SUSPENDED;
   audioPlayer_->suspend();
+  return true;
 }
 
 std::function<void(std::shared_ptr<AudioBus>, int)>

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/AudioContext.h
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/AudioContext.h
@@ -19,8 +19,8 @@ class AudioContext : public BaseAudioContext {
   ~AudioContext() override;
 
   void close();
-  void resume();
-  void suspend();
+  bool resume();
+  bool suspend();
 
  private:
 #ifdef ANDROID


### PR DESCRIPTION
…reject when context is closed

<!-- Reference any GitHub issues resolved by this PR -->

Closes #331

## Introduced changes

<!-- A brief description of the changes -->

- Added `resume` and `suspend` methods to docs and updated them to reject when `AudioContext` is closed.

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added/Conducted relevant tests
- [ ] Performed self-review of the code
- [ ] Updated Web Audio API coverage
- [ ] Added support for web
