### PR TITLE
fix: remove explicit base class destructor calls in AudioRecorder subclasses

### DIFF
--- a/packages/react-native-audio-api/android/src/main/cpp/audioapi/android/core/AndroidAudioRecorder.cpp
+++ b/packages/react-native-audio-api/android/src/main/cpp/audioapi/android/core/AndroidAudioRecorder.cpp
@@ -26,8 +26,6 @@ AndroidAudioRecorder::AndroidAudioRecorder(
 }
 
 AndroidAudioRecorder::~AndroidAudioRecorder() {
-  AudioRecorder::~AudioRecorder();
-
   if (mStream_) {
     mStream_->requestStop();
     mStream_->close();

--- a/packages/react-native-audio-api/ios/audioapi/ios/core/IOSAudioRecorder.mm
+++ b/packages/react-native-audio-api/ios/audioapi/ios/core/IOSAudioRecorder.mm
@@ -40,8 +40,6 @@ IOSAudioRecorder::IOSAudioRecorder(
 
 IOSAudioRecorder::~IOSAudioRecorder()
 {
-  AudioRecorder::~AudioRecorder();
-
   stop();
   [audioRecorder_ cleanup];
 }


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## Introduced changes

<!-- A brief description of the changes -->

- Removed explicit calls to the base class destructor (AudioRecorder::~AudioRecorder()) in both IOSAudioRecorder and AndroidAudioRecorder destructors.
- This resolves a double destruction bug that caused crashes on iOS (and potentially Android) when reloading or backgrounding the app (in my development build using expo)
- The destructors now rely on C++'s automatic destruction order, ensuring safe and correct cleanup of resources.

- Disclaimer: I am not a C++ expert so I had to read myself in a bit. As far as I understood it is not necessary to call the base destructors ([Link](https://stackoverflow.com/questions/677620/do-i-need-to-explicitly-call-the-base-virtual-destructor))

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added/Conducted relevant tests
- [ ] Performed self-review of the code
- [ ] Updated Web Audio API coverage
- [ ] Added support for web
