### PR TITLE
fix: broken link in docs

### DIFF
--- a/packages/audiodocs/docs/sources/audio-buffer-queue-source-node.mdx
+++ b/packages/audiodocs/docs/sources/audio-buffer-queue-source-node.mdx
@@ -48,7 +48,7 @@ The above method lets you add another buffer to queue. Returns `bufferId` that c
 
 | Parameters | Type | Description |
 | :---: | :---: | :---- |
-| `buffer` | [`AudioBuffer`](/sources/audio-buffer) | Buffer with next data. |
+| `buffer` | [`AudioBuffer`](/docs/sources/audio-buffer) | Buffer with next data. |
 
 #### Returns `string`.
 


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## ⚠️ Breaking changes ⚠️

<!-- A brief description of the breaking changes -->

-

## Introduced changes

<!-- A brief description of the changes -->

- renamed link pointing to `AudioBuffer` docs page, path was wrong and it pointed to not existing page

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added/Conducted relevant tests
- [x] Performed self-review of the code
- [ ] Updated Web Audio API coverage
- [ ] Added support for web
