### PR TITLE
fix: removed cppFlags from build.gradle

### DIFF
--- a/packages/react-native-audio-api/android/build.gradle
+++ b/packages/react-native-audio-api/android/build.gradle
@@ -116,7 +116,6 @@ android {
 
     externalNativeBuild {
       cmake {
-        cppFlags "-O2 -frtti -fexceptions -Wall -fstack-protector-all"
         abiFilters (*reactNativeArchitectures())
         arguments "-DANDROID_STL=c++_shared",
                   "-DREACT_NATIVE_MINOR_VERSION=${REACT_NATIVE_MINOR_VERSION}",


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## ⚠️ Breaking changes ⚠️

<!-- A brief description of the breaking changes -->

-

## Introduced changes

<!-- A brief description of the changes -->

- Removed cppFlags from `build.gradle` becasue:
<img width="1780" height="176" alt="image" src="https://github.com/user-attachments/assets/77f9a82c-132b-419b-b94c-02f0f327027d" />


## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added/Conducted relevant tests
- [ ] Performed self-review of the code
- [ ] Updated Web Audio API coverage
- [ ] Added support for web
