### PR TITLE
fix: update onEnded setter to accept null callback in AudioScheduledSourceNode

### DIFF
--- a/packages/react-native-audio-api/src/web-core/AudioScheduledSourceNode.tsx
+++ b/packages/react-native-audio-api/src/web-core/AudioScheduledSourceNode.tsx
@@ -37,7 +37,7 @@ export default class AudioScheduledSourceNode extends AudioNode {
   }
 
   // eslint-disable-next-line accessor-pairs
-  public set onEnded(callback: (event: EventEmptyType) => void) {
+  public set onEnded(callback: (event: EventEmptyType) => void | null) {
     (this.node as globalThis.AudioScheduledSourceNode).onended = callback;
   }
 }


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes RNAA-298

## ⚠️ Breaking changes ⚠️

## Introduced changes

<!-- A brief description of the changes -->

- Broadened the setter signature for `onEnded` to accept `((event: EventEmptyType) => void) | null`.
- This enables clearing the `AudioScheduledSourceNode.onended` handler with `null`, consistent with Web APIs where event handler properties are nullable.
- No changes to runtime code other than assigning the value to `node.onended`.


## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added/Conducted relevant tests
- [ ] Performed self-review of the code
- [ ] Updated Web Audio API coverage
- [ ] Added support for web
