### PR TITLE
fix: double free in decodeWithMemoryBlock

### DIFF
--- a/apps/fabric-example/ios/Podfile.lock
+++ b/apps/fabric-example/ios/Podfile.lock
@@ -3187,7 +3187,7 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: c5c4f5280e4ae0f9f4a739c64c4260fe0b3edaf1
   ReactCodegen: 096bbbb2498ca55f385e2fbd465bfa0211ee8295
   ReactCommon: 25c7f94aee74ddd93a8287756a8ac0830a309544
-  RNAudioAPI: bb7cb1ef3c1e986976570cbafb5fd903cce25af5
+  RNAudioAPI: 78af920559cadf9167dc7229ebddbb10b776411b
   RNGestureHandler: f1dd7f92a0faa2868a919ab53bb9d66eb4ebfcf5
   RNReanimated: e4993dd98196c698cbacc1441a4ac5b855ae56dc
   RNScreens: 833237c48c756d40764540246a501b47dadb2cac

--- a/packages/react-native-audio-api/common/cpp/audioapi/libs/ffmpeg/FFmpegDecoding.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/libs/ffmpeg/FFmpegDecoding.cpp
@@ -277,8 +277,7 @@ decodeWithMemoryBlock(const void *data, size_t size, int sample_rate) {
   MemoryIOContext io_ctx{static_cast<const uint8_t *>(data), size, 0};
 
   constexpr size_t buffer_size = 4096;
-  auto io_buffer = std::unique_ptr<uint8_t, decltype(&av_free)>(
-      static_cast<uint8_t *>(av_malloc(buffer_size)), &av_free);
+  uint8_t *io_buffer = static_cast<uint8_t *>(av_malloc(buffer_size));
   if (io_buffer == nullptr) {
     return nullptr;
   }
@@ -286,7 +285,7 @@ decodeWithMemoryBlock(const void *data, size_t size, int sample_rate) {
   auto avio_ctx =
       std::unique_ptr<AVIOContext, std::function<void(AVIOContext *)>>(
           avio_alloc_context(
-              io_buffer.get(),
+              io_buffer,
               buffer_size,
               0,
               &io_ctx,

--- a/packages/react-native-audio-api/ios/audioapi/ios/core/IOSAudioRecorder.h
+++ b/packages/react-native-audio-api/ios/audioapi/ios/core/IOSAudioRecorder.h
@@ -18,8 +18,7 @@ class IOSAudioRecorder : public AudioRecorder {
   IOSAudioRecorder(
       float sampleRate,
       int bufferLength,
-      const std::shared_ptr<AudioEventHandlerRegistry>
-          &audioEventHandlerRegistry);
+      const std::shared_ptr<AudioEventHandlerRegistry> &audioEventHandlerRegistry);
 
   ~IOSAudioRecorder() override;
 


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## ⚠️ Breaking changes ⚠️

<!-- A brief description of the breaking changes -->

-

## Introduced changes

<!-- A brief description of the changes -->

- fix: double free in decodeWithMemoryBlock 

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added/Conducted relevant tests
- [x] Performed self-review of the code
- [ ] Updated Web Audio API coverage
- [ ] Added support for web
