### PR TITLE
fix: added check for microphone permissions in info.plist

### DIFF
--- a/apps/common-app/src/examples/Record/Record.tsx
+++ b/apps/common-app/src/examples/Record/Record.tsx
@@ -23,7 +23,13 @@ const Record: FC = () => {
 
   useEffect(() => {
     const setup = async () => {
-      await AudioManager.requestRecordingPermissions();
+      try {
+        await AudioManager.requestRecordingPermissions();
+      } catch (err) {
+        console.log(err);
+        console.error('Recording permission denied', err);
+        return;
+      }
       recorderRef.current = new AudioRecorder({
         sampleRate: SAMPLE_RATE,
         bufferLengthInSamples: SAMPLE_RATE,

--- a/packages/audiodocs/docs/system/audio-manager.mdx
+++ b/packages/audiodocs/docs/system/audio-manager.mdx
@@ -177,11 +177,15 @@ Adds callback to be invoked upon hearing an event.
 Brings up the system microphone permissions pop-up on demand. The pop-up automatically shows if microphone data
 is directly requested, but sometimes it is better to ask beforehand.
 
+#### Throws an `error` if there is no NSMicrophoneUsageDescription entry in `Info.plist`
+
 #### Returns promise of [`PermissionStatus`](/docs/system/audio-manager#permissionstatus) type, which is resolved after receiving answer from the system.
 
 ### `checkRecordingPermissions`
 
 Checks if permissions were previously granted.
+
+#### Throws an `error` if there is no NSMicrophoneUsageDescription entry in `Info.plist`
 
 #### Returns promise of [`PermissionStatus`](/docs/system/audio-manager#permissionstatus) type, which is resolved after receiving answer from the system.
 

--- a/packages/react-native-audio-api/ios/audioapi/ios/system/AudioSessionManager.mm
+++ b/packages/react-native-audio-api/ios/audioapi/ios/system/AudioSessionManager.mm
@@ -213,6 +213,15 @@
 
 - (void)requestRecordingPermissions:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject
 {
+  id value = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSMicrophoneUsageDescription"];
+  // if there is no entry NSMicrophoneUsageDescription calling requestRecordPermission will quit an app
+  if (value == nil) {
+    reject(
+        nil,
+        @"There is no NSMicrophoneUsageDescription entry in info.plist file. App cannot access microphone without it.",
+        nil);
+    return;
+  }
   if (@available(iOS 17, *)) {
     [AVAudioSession.sharedInstance requestRecordPermission:^(BOOL granted) {
       if (granted) {


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes RNAA-287

## ⚠️ Breaking changes ⚠️

<!-- A brief description of the breaking changes -->

-

## Introduced changes

<!-- A brief description of the changes -->

- no entry NSMicrophoneUsageDescription in info.plist caused app to exit if requesting for permissions, added if that checks if it is available, if not throws an error

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added/Conducted relevant tests
- [x] Performed self-review of the code
- [ ] Updated Web Audio API coverage
- [ ] Added support for web
