### PR TITLE
fix: changed worklets to be truly optional on npm

### DIFF
--- a/packages/react-native-audio-api/package.json
+++ b/packages/react-native-audio-api/package.json
@@ -84,7 +84,12 @@
   "peerDependencies": {
     "react": "*",
     "react-native": "*",
-    "react-native-worklets": "~0.6.0"
+    "react-native-worklets": ">= 0.6.0"
+  },
+  "peerDependenciesMeta": {
+    "react-native-worklets": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@babel/cli": "^7.20.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10933,7 +10933,10 @@ __metadata:
   peerDependencies:
     react: "*"
     react-native: "*"
-    react-native-worklets: ~0.6.0
+    react-native-worklets: ">= 0.6.0"
+  peerDependenciesMeta:
+    react-native-worklets:
+      optional: true
   bin:
     setup-rn-audio-api-web: ./scripts/setup-rn-audio-api-web.js
   languageName: unknown


### PR DESCRIPTION

Closes #788 

## ⚠️ Breaking changes ⚠️
-

## Introduced changes
- worklets should be properly treated as optionall

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [ ] Updated relevant documentation
- [x] Added/Conducted relevant tests
- [x] Performed self-review of the code
- [ ] Updated Web Audio API coverage
- [ ] Added support for web
