### PR TITLE
fix: fixed start method to accept optional offset parameter

### DIFF
--- a/packages/react-native-audio-api/common/cpp/audioapi/HostObjects/sources/AudioBufferQueueSourceNodeHostObject.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/HostObjects/sources/AudioBufferQueueSourceNodeHostObject.cpp
@@ -21,11 +21,15 @@ AudioBufferQueueSourceNodeHostObject::AudioBufferQueueSourceNodeHostObject(
 
 JSI_HOST_FUNCTION_IMPL(AudioBufferQueueSourceNodeHostObject, start) {
   auto when = args[0].getNumber();
-  auto offset = args[1].getNumber();
 
   auto audioBufferQueueSourceNode = std::static_pointer_cast<AudioBufferQueueSourceNode>(node_);
 
-  audioBufferQueueSourceNode->start(when, offset);
+  if (!args[1].isNumber()) {
+    audioBufferQueueSourceNode->start(when);
+  } else {
+    auto offset = args[1].getNumber();
+    audioBufferQueueSourceNode->start(when, offset);
+  }
 
   return jsi::Value::undefined();
 }

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioBufferQueueSourceNode.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioBufferQueueSourceNode.cpp
@@ -50,10 +50,14 @@ void AudioBufferQueueSourceNode::stop(double when) {
   isPaused_ = false;
 }
 
-void AudioBufferQueueSourceNode::start(double when, double offset) {
+void AudioBufferQueueSourceNode::start(double when) {
   isPaused_ = false;
   stopTime_ = -1.0;
   AudioScheduledSourceNode::start(when);
+}
+
+void AudioBufferQueueSourceNode::start(double when, double offset) {
+  start(when);
 
   if (buffers_.empty()) {
     return;

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioBufferQueueSourceNode.h
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioBufferQueueSourceNode.h
@@ -22,7 +22,7 @@ class AudioBufferQueueSourceNode : public AudioBufferBaseSourceNode {
 
   void stop(double when) override;
 
-  using AudioScheduledSourceNode::start;
+  void start(double when) override;
   void start(double when, double offset);
   void pause();
 

--- a/packages/react-native-audio-api/src/core/AudioBufferQueueSourceNode.ts
+++ b/packages/react-native-audio-api/src/core/AudioBufferQueueSourceNode.ts
@@ -24,14 +24,14 @@ export default class AudioBufferQueueSourceNode extends AudioBufferBaseSourceNod
     (this.node as IAudioBufferQueueSourceNode).clearBuffers();
   }
 
-  public override start(when: number = 0, offset: number = 0): void {
+  public override start(when: number = 0, offset?: number): void {
     if (when < 0) {
       throw new RangeError(
         `when must be a finite non-negative number: ${when}`
       );
     }
 
-    if (offset < 0) {
+    if (offset && offset < 0) {
       throw new RangeError(
         `offset must be a finite non-negative number: ${offset}`
       );


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## ⚠️ Breaking changes ⚠️

<!-- A brief description of the breaking changes -->

-

## Introduced changes

<!-- A brief description of the changes -->

- Changed offset to be an optional parameter. Without it `pause()` -> `start()` combination starts from the beginning of current buffer.

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [x] Added/Conducted relevant tests
- [x] Performed self-review of the code
- [ ] Updated Web Audio API coverage
- [ ] Added support for web
