### PR TITLE
chore: removed react-native-worklets from peerDependencies

### DIFF
--- a/packages/react-native-audio-api/package.json
+++ b/packages/react-native-audio-api/package.json
@@ -83,8 +83,7 @@
   },
   "peerDependencies": {
     "react": "*",
-    "react-native": "*",
-    "react-native-worklets": "*"
+    "react-native": "*"
   },
   "devDependencies": {
     "@babel/cli": "^7.20.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10942,7 +10942,6 @@ __metadata:
   peerDependencies:
     react: "*"
     react-native: "*"
-    react-native-worklets: "*"
   bin:
     setup-rn-audio-api-web: ./scripts/setup-rn-audio-api-web.js
   languageName: unknown


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## ⚠️ Breaking changes ⚠️

<!-- A brief description of the breaking changes -->

-

## Introduced changes

<!-- A brief description of the changes -->

- removed `react-native-worklets` from peerDependencies

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added/Conducted relevant tests
- [ ] Performed self-review of the code
- [ ] Updated Web Audio API coverage
- [ ] Added support for web
