### PR TITLE
fix: double start message

### DIFF
--- a/packages/react-native-audio-api/android/src/main/cpp/audioapi/android/core/AndroidAudioRecorder.cpp
+++ b/packages/react-native-audio-api/android/src/main/cpp/audioapi/android/core/AndroidAudioRecorder.cpp
@@ -111,7 +111,7 @@ Result<std::string, std::string> AndroidAudioRecorder::start() {
   std::scoped_lock startLock(callbackMutex_, fileWriterMutex_, adapterNodeMutex_);
 
   if (isRecording()) {
-    return Result<std::string, std::string>::Ok(std::format("file://{}", filePath_));
+    return Result<std::string, std::string>::Err("Recorder is already recording");
   }
 
   auto streamResult = openAudioStream();

--- a/packages/react-native-audio-api/ios/audioapi/ios/core/IOSAudioRecorder.mm
+++ b/packages/react-native-audio-api/ios/audioapi/ios/core/IOSAudioRecorder.mm
@@ -74,7 +74,7 @@ IOSAudioRecorder::~IOSAudioRecorder()
 Result<std::string, std::string> IOSAudioRecorder::start()
 {
   if (isRecording()) {
-    return Result<std::string, std::string>::Err("Already recording");
+    return Result<std::string, std::string>::Err("Recorder is already recording");
   }
 
   std::scoped_lock startLock(callbackMutex_, fileWriterMutex_, adapterNodeMutex_);


### PR DESCRIPTION
## Introduced changes

<!-- A brief description of the changes -->

- [Recorder] match double start behaviour on both platforms

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added/Conducted relevant tests
- [x] Performed self-review of the code
- [x] Updated Web Audio API coverage
- [ ] Added support for web
