### PR TITLE
Fix link formatting in audiodocs README

### DIFF
--- a/packages/audiodocs/README.md
+++ b/packages/audiodocs/README.md
@@ -1,3 +1,3 @@
 # React Native Audio API documentation
 
-The docs are available at (https://software-mansion.github.io/react-native-audio-api/)(https://software-mansion.github.io/react-native-audio-api/)
+The docs are available at <https://software-mansion.github.io/react-native-audio-api/>


### PR DESCRIPTION
## Introduced changes

Tiny docs change to fix broken Markdown link formatting

-

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added/Conducted relevant tests
- [x] Performed self-review of the code
- [x] Updated Web Audio API coverage
- [x] Added support for web
