### PR TITLE
refactor: removed hardcoded alignment

### DIFF
--- a/packages/react-native-audio-api/common/cpp/audioapi/utils/SpscChannel.hpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/utils/SpscChannel.hpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <atomic>
 #include <memory>
+#include <new>
 #include <thread>
 #include <type_traits>
 #include <utility>
@@ -413,15 +414,17 @@ class InnerChannel {
   T *buffer_;
 
   /// Producer-side data (accessed by sender thread)
-  alignas(64) std::atomic<size_t> sendCursor_{0};
-  alignas(64) size_t rcvCursorCache_{0}; // reduces cache coherency
+  alignas(std::hardware_destructive_interference_size) std::atomic<size_t> sendCursor_{0};
+  alignas(std::hardware_destructive_interference_size) size_t rcvCursorCache_{
+      0}; // reduces cache coherency
 
   /// Consumer-side data (accessed by receiver thread)
-  alignas(64) std::atomic<size_t> rcvCursor_{0};
-  alignas(64) size_t sendCursorCache_{0}; // reduces cache coherency
+  alignas(std::hardware_destructive_interference_size) std::atomic<size_t> rcvCursor_{0};
+  alignas(std::hardware_destructive_interference_size) size_t sendCursorCache_{
+      0}; // reduces cache coherency
 
   /// Flag indicating if the oldest element is occupied
-  alignas(64) std::atomic<bool> oldestOccupied_{false};
+  alignas(std::hardware_destructive_interference_size) std::atomic<bool> oldestOccupied_{false};
 
   friend class Sender<T, Strategy, Wait>;
   friend class Receiver<T, Strategy, Wait>;


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## Introduced changes

<!-- A brief description of the changes -->

- changed hard coded 64 value to `std::hardware_destructive_interference_size`, which resolves to "minimum offset between two objects to avoid false sharing". It almost always resolves to 64, but its not guaranteed, it is implementation defined.

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added/Conducted relevant tests
- [ ] Performed self-review of the code
- [ ] Updated Web Audio API coverage
- [ ] Added support for web
