### PR TITLE
refactor: moved ma implementation to common files

### DIFF
--- a/apps/fabric-example/ios/Podfile.lock
+++ b/apps/fabric-example/ios/Podfile.lock
@@ -2626,6 +2626,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - RNAudioAPI/audioapi/audioapi_dsp (= 0.12.0)
     - RNAudioAPI/audioapi/ios (= 0.12.0)
+    - RNAudioAPI/audioapi/miniaudio_impl (= 0.12.0)
     - RNWorklets
     - SocketRocket
     - Yoga
@@ -2659,6 +2660,35 @@ PODS:
     - SocketRocket
     - Yoga
   - RNAudioAPI/audioapi/ios (0.12.0):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-jsi
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-renderercss
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - RNWorklets
+    - SocketRocket
+    - Yoga
+  - RNAudioAPI/audioapi/miniaudio_impl (0.12.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -3291,7 +3321,7 @@ SPEC CHECKSUMS:
   FBLazyVector: 309703e71d3f2f1ed7dc7889d58309c9d77a95a4
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
-  hermes-engine: f93b5009d8ccd9429fe2a772351980df8a22a413
+  hermes-engine: ceeea60c009bd0e5901c2902d127df94e33af86d
   RCT-Folly: 846fda9475e61ec7bcbf8a3fe81edfcaeb090669
   RCTDeprecation: a41bbdd9af30bf2e5715796b313e44ec43eefff1
   RCTRequired: 7be34aabb0b77c3cefe644528df0fa0afad4e4d0
@@ -3364,7 +3394,7 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 0eb286cc274abb059ee601b862ebddac2e681d01
   ReactCodegen: b8e56b780fffe6edd6405be0af4a1e3049a937f7
   ReactCommon: ac934cb340aee91282ecd6f273a26d24d4c55cae
-  RNAudioAPI: 8db04de40902933a82131908afb9aa2796e1f02a
+  RNAudioAPI: c25fd842b566d5800af85d9acdd73318284a0e81
   RNGestureHandler: cd4be101cfa17ea6bbd438710caa02e286a84381
   RNReanimated: 132940c4c15ca2757f4f7d1fd7c9c3c01dbc4689
   RNScreens: ffbb0296608eb3560de641a711bbdb663ed1f6b4

--- a/packages/react-native-audio-api/RNAudioAPI.podspec
+++ b/packages/react-native-audio-api/RNAudioAPI.podspec
@@ -46,6 +46,14 @@ Pod::Spec.new do |s|
       sss.header_mappings_dir = "common/cpp/audioapi/dsp"
       sss.compiler_flags = "-O3"
     end
+
+    # compile miniaudio implementation file as objective-c++
+    ss.subspec "miniaudio_impl" do |sss|
+      sss.source_files = "common/cpp/audioapi/utils/MiniaudioImplementation.cpp"
+      sss.header_dir = "audioapi/libs"
+      sss.header_mappings_dir = "common/cpp/audioapi/libs"
+      sss.compiler_flags = "-x objective-c++"
+    end
   end
 
   if worklets_enabled

--- a/packages/react-native-audio-api/common/cpp/audioapi/utils/MiniaudioImplementation.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/utils/MiniaudioImplementation.cpp
@@ -1,8 +1,7 @@
-/// Miniaudio implementation for Android platform.
+/// Miniaudio implementation
 /// this define tells the miniaudio to also include the definitions and not only declarations.
 /// Which should be done only once in the whole project.
 /// This make its safe to include the header file in multiple places, without causing multiple definition errors.
-/// TODO: Consider moving this file to common scope to re-use the miniaudio also for iOS platform.
 #define MINIAUDIO_IMPLEMENTATION
 #define MA_DEBUG_OUTPUT
 #include <audioapi/libs/miniaudio/miniaudio.h>

--- a/packages/react-native-audio-api/ios/audioapi/ios/core/utils/AudioDecoder.mm
+++ b/packages/react-native-audio-api/ios/audioapi/ios/core/utils/AudioDecoder.mm
@@ -1,8 +1,6 @@
-#define MINIAUDIO_IMPLEMENTATION
-#import <audioapi/libs/miniaudio/miniaudio.h>
-
 #include <audioapi/libs/miniaudio/decoders/libopus/miniaudio_libopus.h>
 #include <audioapi/libs/miniaudio/decoders/libvorbis/miniaudio_libvorbis.h>
+#include <audioapi/libs/miniaudio/miniaudio.h>
 
 #include <audioapi/core/sources/AudioBuffer.h>
 #include <audioapi/core/utils/AudioDecoder.h>


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes RNAA-379

## ⚠️ Breaking changes ⚠️

<!-- A brief description of the breaking changes -->

-

## Introduced changes

<!-- A brief description of the changes -->

- moved miniaudio implementation file to common namespace to be the same for both android and ios

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added/Conducted relevant tests
- [ ] Performed self-review of the code
- [ ] Updated Web Audio API coverage
- [ ] Added support for web
