### PR TITLE
refactor: removed compilation flag and cleanup cmake

### DIFF
--- a/packages/react-native-audio-api/android/src/main/cpp/audioapi/CMakeLists.txt
+++ b/packages/react-native-audio-api/android/src/main/cpp/audioapi/CMakeLists.txt
@@ -99,21 +99,14 @@ target_include_directories(
   ${INCLUDE_LIBRARIES}
 )
 
-if(ReactAndroid_VERSION_MINOR GREATER_EQUAL 76)
-  set(RN_VERSION_LINK_LIBRARIES
-    ReactAndroid::reactnative
-  )
-else()
-  set(RN_VERSION_LINK_LIBRARIES
-    ReactAndroid::folly_runtime
-    ReactAndroid::react_nativemodule_core
-    ReactAndroid::glog
-    ReactAndroid::reactnativejni
-  )
-endif()
-
 set(RN_VERSION_LINK_LIBRARIES
   ReactAndroid::reactnative
+)
+
+target_compile_options(
+  react-native-audio-api
+  PRIVATE
+  -Wno-mismatched-tags
 )
 
 if(RN_AUDIO_API_WORKLETS_ENABLED)

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/AudioNode.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/AudioNode.cpp
@@ -17,8 +17,8 @@ AudioNode::AudioNode(std::shared_ptr<BaseAudioContext> context) : context_(conte
 }
 
 AudioNode::AudioNode(std::shared_ptr<BaseAudioContext> context, const AudioNodeOptions &options)
-    : context_(context),
-      channelCount_(options.channelCount),
+    : channelCount_(options.channelCount),
+      context_(context),
       channelCountMode_(options.channelCountMode),
       channelInterpretation_(options.channelInterpretation) {
   audioBus_ =


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## ⚠️ Breaking changes ⚠️

<!-- A brief description of the breaking changes -->

-

## Introduced changes

<!-- A brief description of the changes -->

- reordered constructor initialization list to match declaration
- removed flag `-Wmismatched-tags` [-Wmismatched-tags](https://releases.llvm.org/20.1.0/tools/clang/docs/DiagnosticsReference.html#id582), it only matters when c++ is compiled with msvc, but android and ios are compiled with clang so that is not the case
- we support only RN 0.76+, we don't need to have if in cmake no more (it did not work also, because line after always set flag to certain value overriding previous set)

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [x] Added/Conducted relevant tests
- [x] Performed self-review of the code
- [ ] Updated Web Audio API coverage
- [ ] Added support for web
