### PR TITLE
fix: handle undefined fileNameOverride in Recorder.start()

### DIFF
--- a/packages/react-native-audio-api/common/cpp/audioapi/HostObjects/inputs/AudioRecorderHostObject.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/HostObjects/inputs/AudioRecorderHostObject.cpp
@@ -12,6 +12,7 @@
 #include <audioapi/ios/core/IOSAudioRecorder.h>
 #endif
 #include <memory>
+#include <string>
 
 namespace audioapi {
 
@@ -41,7 +42,12 @@ AudioRecorderHostObject::AudioRecorderHostObject(
 }
 
 JSI_HOST_FUNCTION_IMPL(AudioRecorderHostObject, start) {
-  auto fileNameOverride = count > 0 ? args[0].getString(runtime).utf8(runtime) : "";
+  std::string fileNameOverride = "";
+
+  if (count > 0 && !args[0].isUndefined()) {
+    fileNameOverride = args[0].getString(runtime).utf8(runtime);
+  }
+
   auto result = audioRecorder_->start(fileNameOverride);
   auto jsResult = jsi::Object(runtime);
 


### PR DESCRIPTION
Calling `Recorder.start()` without a `fileNameOverride` crashes the app.

**Repro:**
```typescript
Recorder.enableFileOutput();
Recorder.start(); // crashes
```

Crash seems to have been introduced by  #898.

In `AudioRecorderHostObject.cpp`, the code checked `count > 0` but then called `getString()` directly on `args[0]`, which crashes when the argument is `undefined`.