### PR TITLE
refactor: added js callback when oboe throws error

### DIFF
--- a/packages/react-native-audio-api/common/cpp/audioapi/core/utils/AudioFileWriter.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/utils/AudioFileWriter.cpp
@@ -29,9 +29,8 @@ void AudioFileWriter::invokeOnErrorCallback(const std::string &message) {
     return;
   }
 
-  std::unordered_map<std::string, EventValue> eventPayload = {};
-  eventPayload.insert({"message", message});
-  audioEventHandlerRegistry_->invokeHandlerWithEventBody("error", callbackId, eventPayload);
+  std::unordered_map<std::string, EventValue> eventPayload = {{"message", message}};
+  audioEventHandlerRegistry_->invokeHandlerWithEventBody("recorderError", callbackId, eventPayload);
 }
 
 bool AudioFileWriter::isFileOpen() {

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/utils/AudioRecorderCallback.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/utils/AudioRecorderCallback.cpp
@@ -97,9 +97,8 @@ void AudioRecorderCallback::invokeOnErrorCallback(const std::string &message) {
     return;
   }
 
-  std::unordered_map<std::string, EventValue> eventPayload = {};
-  eventPayload.insert({"message", message});
-  audioEventHandlerRegistry_->invokeHandlerWithEventBody("error", callbackId, eventPayload);
+  std::unordered_map<std::string, EventValue> eventPayload = {{"message", message}};
+  audioEventHandlerRegistry_->invokeHandlerWithEventBody("recorderError", callbackId, eventPayload);
 }
 
 } // namespace audioapi


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes RNAA-378

## ⚠️ Breaking changes ⚠️

<!-- A brief description of the breaking changes -->

-

## Introduced changes

<!-- A brief description of the changes -->

- renamed error invocation in native side from `error` to `recorderError`
- when oboe fails with error, callback is invoked to js

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added/Conducted relevant tests
- [x] Performed self-review of the code
- [ ] Updated Web Audio API coverage
- [ ] Added support for web
