### PR TITLE
Enhance WorkletNode example with AudioManager, context resume

### DIFF
--- a/packages/audiodocs/docs/worklets/worklet-node.mdx
+++ b/packages/audiodocs/docs/worklets/worklet-node.mdx
@@ -30,14 +30,17 @@ Or by using `BaseAudioContext` factory method:
 
 ## Example
 ```tsx
-import { AudioContext, AudioRecorder } from 'react-native-audio-api';
+import { AudioContext, AudioRecorder, AudioManager } from 'react-native-audio-api';
+
+AudioManager.setAudioSessionOptions({
+    iosCategory: "playAndRecord",
+    iosMode: "measurement",
+    iosOptions: ["mixWithOthers"],
+})
 
 // This example shows how we can use a WorkletNode to process microphone audio data in real-time.
-function App() {
-    const recorder = new AudioRecorder({
-      sampleRate: 16000,
-      bufferLengthInSamples: 16000,
-    });
+async function App() {
+    const recorder = new AudioRecorder();
 
     const audioContext = new AudioContext({ sampleRate: 16000 });
     const worklet = (audioData: Array<Float32Array>, inputChannelCount: number) => {
@@ -50,10 +53,15 @@ function App() {
     const workletNode = audioContext.createWorkletNode(worklet, 1024, 2, 'UIRuntime');
     const adapterNode = audioContext.createRecorderAdapter();
 
+    const canSetAudioSessionActivity = await AudioManager.setAudioSessionActivity(true);
+    if (!canSetAudioSessionActivity) {
+        throw new Error("Could not activate the audio session");
+    }
     adapterNode.connect(workletNode);
     workletNode.connect(audioContext.destination);
     recorder.connect(adapterNode);
     recorder.start();
+    audioContext.resume();
 }
 ```
 


### PR DESCRIPTION
Updated the example to include AudioManager for audio session configuration, added correct point for `audioContext.resume()` to occur, and changed the App function to be asynchronous.

<!-- Reference any GitHub issues resolved by this PR -->

In reference to learning from #804 #903 #912 and to save future developers the same pain I went through!


## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added/Conducted relevant tests
- [ ] Performed self-review of the code
- [ ] Updated Web Audio API coverage
- [ ] Added support for web
- [ ] Updated old arch android spec file
