### PR TITLE
Fix/recorder example or test

### DIFF
--- a/apps/common-app/src/examples/Record/Record.tsx
+++ b/apps/common-app/src/examples/Record/Record.tsx
@@ -190,7 +190,6 @@ const Record: FC = () => {
 
     const tNow = audioContext.currentTime;
     let nextStartAt = tNow + 1;
-    await new Promise((resolve) => setTimeout(resolve, 1000));
 
     capturedBuffers.forEach((buffer) => {
       const source = audioContext.createBufferSource();


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes RNAA-428

## Introduced changes

<!-- A brief description of the changes -->

- fixes issue with recording "example"/"text" screen where record for replay were not actually starting the recording,
- adds more "cleanup" (suspend/resume) logic when switching between recording and playback to avoid unnecessary echos in record for replay test

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added/Conducted relevant tests
- [ ] Performed self-review of the code
- [ ] Updated Web Audio API coverage
- [ ] Added support for web
- [ ] Updated old arch android spec file
