### PR TITLE
fix: use bt hfp value for backward compability

### DIFF
--- a/packages/react-native-audio-api/ios/audioapi/ios/system/AudioSessionManager.mm
+++ b/packages/react-native-audio-api/ios/audioapi/ios/system/AudioSessionManager.mm
@@ -406,7 +406,12 @@ static AudioSessionManager *_sharedInstance = nil;
     }
 
     if ([option isEqualToString:@"allowBluetoothHFP"]) {
-      options |= AVAudioSessionCategoryOptionAllowBluetoothHFP;
+      // XCode 26.x (default support SDK >= 26.x) uses AVAudioSessionCategoryOptionAllowBluetoothHFP as new standard for every platfrom (down to iOS 1.0)
+      // Older Xcode (default support SDKs) versions doesn't define it at all.
+      // Both (AVAudioSessionCategoryOptionAllowBluetooth in SDK < 26.x) and (AVAudioSessionCategoryOptionAllowBluetoothHFP in SDK >= 26.x) resolve to this value
+      // We use it here directly as there is no reliable way to switch between them (no @available for this).
+      // TODO: replace with AVAudioSessionCategoryOptionAllowBluetoothHFP once XCode 16.x will dig its grave
+      options |= 0x4;
     }
 
     if ([option isEqualToString:@"defaultToSpeaker"]) {


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #945 

## Introduced changes

<!-- A brief description of the changes -->

- uses value of old allow bluetooth/ new allow bluetoothHFP directly to avoid backward compability issues

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [ ] Updated relevant documentation
- [x] Added/Conducted relevant tests
- [x] Performed self-review of the code
- [ ] Updated Web Audio API coverage
- [ ] Added support for web
- [x] Updated old arch android spec file
