### PR TITLE
Remove  audio thread audiobufferlist from file writer autorelease pool

### DIFF
--- a/packages/react-native-audio-api/ios/audioapi/ios/core/utils/IOSFileWriter.mm
+++ b/packages/react-native-audio-api/ios/audioapi/ios/core/utils/IOSFileWriter.mm
@@ -179,6 +179,8 @@ void IOSFileWriter::taskOffloaderFunction(WriterData data)
             audioBufferList->mBuffers[i].mData,
             audioBufferList->mBuffers[i].mDataByteSize);
       }
+
+      audioBufferList = nullptr;
       converterInputBuffer_.frameLength = numFrames;
 
       [audioFile_ writeFromBuffer:converterInputBuffer_ error:&error];

--- a/packages/react-native-audio-api/ios/audioapi/ios/core/utils/IOSRecorderCallback.mm
+++ b/packages/react-native-audio-api/ios/audioapi/ios/core/utils/IOSRecorderCallback.mm
@@ -152,6 +152,7 @@ void IOSRecorderCallback::taskOffloaderFunction(CallbackData data)
         circularBuffer_[i]->push_back(data, numFrames);
       }
 
+      inputBuffer = nullptr;
       if (circularBuffer_[0]->getNumberOfAvailableFrames() >= bufferLength_) {
         emitAudioData();
       }
@@ -167,6 +168,7 @@ void IOSRecorderCallback::taskOffloaderFunction(CallbackData data)
           inputBuffer->mBuffers[i].mDataByteSize);
     }
 
+    inputBuffer = nullptr;
     converterInputBuffer_.frameLength = numFrames;
 
     __block BOOL handedOff = false;


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #953 

## Introduced changes

<!-- A brief description of the changes -->

- Dont allow for file writer or callback worker threads to deallocate audio thread's buffers

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added/Conducted relevant tests
- [x] Performed self-review of the code
- [ ] Updated Web Audio API coverage
- [ ] Added support for web
- [ ] Updated old arch android spec file
