### PR TITLE
fix: two ring-buffer bugs in DelayNode::delayBufferOperation

### DIFF
--- a/packages/react-native-audio-api/common/cpp/audioapi/core/effects/DelayNode.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/effects/DelayNode.cpp
@@ -43,8 +43,7 @@ void DelayNode::delayBufferOperation(
 
   // handle buffer wrap around
   if (operationStartingIndex + framesToProcess > delayBuffer_->getSize()) {
-    int framesToEnd =
-        static_cast<int>(delayBuffer_->getSize()) - static_cast<int>(operationStartingIndex);
+    auto framesToEnd = static_cast<int>(delayBuffer_->getSize() - operationStartingIndex);
 
     if (action == BufferAction::WRITE) {
       delayBuffer_->sum(

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/effects/DelayNode.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/effects/DelayNode.cpp
@@ -44,7 +44,7 @@ void DelayNode::delayBufferOperation(
   // handle buffer wrap around
   if (operationStartingIndex + framesToProcess > delayBuffer_->getSize()) {
     int framesToEnd =
-        static_cast<int>(operationStartingIndex + framesToProcess - delayBuffer_->getSize());
+        static_cast<int>(delayBuffer_->getSize()) - static_cast<int>(operationStartingIndex);
 
     if (action == BufferAction::WRITE) {
       delayBuffer_->sum(

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/effects/DelayNode.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/effects/DelayNode.cpp
@@ -52,6 +52,7 @@ void DelayNode::delayBufferOperation(
     } else { // READ
       processingBuffer->sum(
           *delayBuffer_, operationStartingIndex, processingBufferStartIndex, framesToEnd);
+      delayBuffer_->zero(operationStartingIndex, framesToEnd);
     }
 
     operationStartingIndex = 0;


### PR DESCRIPTION
Closes #997 

## Summary

Two bugs in `DelayNode::delayBufferOperation` that together cause periodic clicking artifacts and inaudible delay echo on Android.

### Bug 1 — Inverted wraparound index (`framesToEnd`)

`framesToEnd` was computed as the **overflow count** (frames past the buffer end) but used as the size of the **pre-wrap chunk** (frames remaining before the buffer end):

```cpp
// Before (buggy): overflow count, not pre-wrap count
int framesToEnd = operationStartingIndex + framesToProcess - delayBuffer_->getSize();

// After: correct pre-wrap count
int framesToEnd = static_cast<int>(delayBuffer_->getSize()) - static_cast<int>(operationStartingIndex);
```

This caused audio to be written/read at wrong positions on every buffer boundary crossing.

### Bug 2 — Pre-wrap chunk not zeroed after READ

The READ path only zeroed the second (post-wrap) chunk. The first chunk — frames from `operationStartingIndex` to the buffer end — was consumed but never cleared. On the next full buffer rotation (~1 s for a 1 s max-delay buffer) that stale data was re-read as new audio:

```cpp
} else { // READ
  processingBuffer->sum(
      *delayBuffer_, operationStartingIndex, processingBufferStartIndex, framesToEnd);
  delayBuffer_->zero(operationStartingIndex, framesToEnd);  // added
}
```

## Symptoms (Android, Nokia XR20, sampleRate 48000)

- Periodic metronome-like clicking whose rate scales with `delayTime.value` — fixed by Bug 1
- ~1 s periodic tick independent of delay time — fixed by Bug 2
- Delay echo inaudible — resolved once both fixes are applied

## Test plan

- [ ] Create `AudioContext`, wire `OscillatorNode → DelayNode → GainNode(wet) → destination` with a separate dry path
- [ ] Set `delayTime` to a value < `maxDelayTime` (e.g. 0.3 s, 0.95 s)
- [ ] Start oscillator, play for several seconds — confirm no periodic clicking
- [ ] Stop oscillator — confirm echo tail is audible for ~`delayTime` seconds after stop
- [ ] Verify no regression on iOS

Tested on Android (Nokia XR20, Android 14) via a local dev build with both fixes applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)