### PR TITLE
fix(ios): reuse AVAudioEngine instance in rebuildAudioEngine to prevent owningEngine assertion crash

### DIFF
--- a/packages/react-native-audio-api/ios/audioapi/ios/system/AudioEngine.mm
+++ b/packages/react-native-audio-api/ios/audioapi/ios/system/AudioEngine.mm
@@ -108,9 +108,8 @@ static AudioEngine *_sharedInstance = nil;
     return;
   }
 
-  // Stop just in case, reset the engine and build it from scratch
+  // Stop just in case and rebuild graph connections.
   [self stopIfNecessary];
-  [self.audioEngine reset];
   [self rebuildAudioEngine];
 
   // If shouldResume is false, mark the engine as paused and wait
@@ -140,33 +139,51 @@ static AudioEngine *_sharedInstance = nil;
   return self.state;
 }
 
-/// @brief Rebuilds the audio engine by re-attaching and re-connecting all source nodes and input node.
+/// @brief Rebuilds audio graph connections on the current engine instance.
 - (void)rebuildAudioEngine
 {
-  if (self.audioEngine != nil) {
-    for (id sourceNodeId in self.sourceNodes) {
-      AVAudioSourceNode *sourceNode = [self.sourceNodes valueForKey:sourceNodeId];
+  BOOL createdFreshEngine = NO;
+  if (self.audioEngine == nil) {
+    self.audioEngine = [[AVAudioEngine alloc] init];
+    createdFreshEngine = YES;
+  }
 
-      [self.audioEngine detachNode:sourceNode];
-    }
+  if ([self.audioEngine isRunning]) {
+    [self.audioEngine stop];
+  }
 
-    if (self.inputNode) {
-      [self.audioEngine detachNode:self.inputNode];
+  [self.audioEngine reset];
+
+  // Keep nodes attached to the same engine instance and only rebuild
+  // connections. This avoids reusing nodes across engine instances.
+  for (id sourceNodeId in self.sourceNodes) {
+    AVAudioSourceNode *sourceNode = [self.sourceNodes valueForKey:sourceNodeId];
+    if (createdFreshEngine) {
+      [self.audioEngine attachNode:sourceNode];
+    } else {
+      [self.audioEngine disconnectNodeInput:sourceNode];
+      [self.audioEngine disconnectNodeOutput:sourceNode];
     }
   }
 
-  self.audioEngine = [[AVAudioEngine alloc] init];
+  if (self.inputNode) {
+    if (createdFreshEngine) {
+      [self.audioEngine attachNode:self.inputNode];
+    } else {
+      [self.audioEngine disconnectNodeInput:self.inputNode];
+      [self.audioEngine disconnectNodeOutput:self.inputNode];
+      [self.audioEngine disconnectNodeOutput:self.audioEngine.inputNode];
+    }
+  }
 
   for (id sourceNodeId in self.sourceNodes) {
     AVAudioSourceNode *sourceNode = [self.sourceNodes valueForKey:sourceNodeId];
     AVAudioFormat *format = [self.sourceFormats valueForKey:sourceNodeId];
 
-    [self.audioEngine attachNode:sourceNode];
     [self.audioEngine connect:sourceNode to:self.audioEngine.mainMixerNode format:format];
   }
 
   if (self.inputNode) {
-    [self.audioEngine attachNode:self.inputNode];
     [self.audioEngine connect:self.audioEngine.inputNode to:self.inputNode format:nil];
   }
 }
@@ -188,7 +205,6 @@ static AudioEngine *_sharedInstance = nil;
 
   if (self.state == AudioEngineState::AudioEngineStateInterrupted) {
     [self.audioEngine stop];
-    [self.audioEngine reset];
     [self rebuildAudioEngine];
   }
 


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #1013

## ⚠️ Breaking changes ⚠️

- None.

## Introduced changes

- reworks iOS interruption recovery in `AudioEngine.mm` to rebuild graph connections on the current `AVAudioEngine` instance instead of creating a new engine and re-attaching the same node objects
- removes redundant `reset` calls before `rebuildAudioEngine`, since rebuild now resets the current engine internally
- avoids reusing `AVAudioSourceNode` / `AVAudioSinkNode` instances across different `AVAudioEngine` instances, which can trigger AVFAudio's `owningEngine` assertion

## Notes for reviewers

- This change is intentionally narrow and only touches the iOS rebuild path in `packages/react-native-audio-api/ios/audioapi/ios/system/AudioEngine.mm`.
- I do not have a deterministic public repro yet. The fix is based on a production crash signature plus a downstream patch that mitigated the crash in production.
- Upstream `main` still had the detach-create-reattach flow when this PR was prepared on 2026-04-10.
- Open PR #1005 also touches `AudioEngine.mm`, but it still recreates the engine in `rebuildAudioEngine`, so it does not address this specific `owningEngine` assertion. If that PR lands first, this patch will probably need a small rebase.

## Checklist

- [x] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added/Conducted relevant tests
- [x] Performed self-review of the code
- [ ] Updated Web Audio API coverage
- [ ] Added support for web
- [ ] Updated old arch android spec file