### PR TITLE
refactor: queue to 128 elements

### DIFF
--- a/packages/react-native-audio-api/common/cpp/audioapi/core/utils/Constants.h
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/utils/Constants.h
@@ -46,5 +46,5 @@ constexpr std::size_t hardware_destructive_interference_size = 64;
 #endif
 
 // audio param
-inline constexpr size_t AUDIO_PARAM_MAX_QUEUED_EVENTS = 32;
+inline constexpr size_t AUDIO_PARAM_MAX_QUEUED_EVENTS = 128;
 } // namespace audioapi


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## ⚠️ Breaking changes ⚠️

<!-- A brief description of the breaking changes -->

-

## Introduced changes

<!-- A brief description of the changes -->

- increase queue size to 128, because during testing it turned out that 32 is too low

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added/Conducted relevant tests
- [ ] Performed self-review of the code
- [ ] Updated Web Audio API coverage
- [ ] Added support for web
- [ ] Updated old arch android spec file
