### PR TITLE
fix: assets via memory block

### DIFF
--- a/packages/react-native-audio-api/android/src/main/java/com/swmansion/audioapi/AudioAPIModule.kt
+++ b/packages/react-native-audio-api/android/src/main/java/com/swmansion/audioapi/AudioAPIModule.kt
@@ -2,6 +2,7 @@ package com.swmansion.audioapi
 
 import android.media.AudioManager
 import android.os.Build
+import android.util.Base64
 import androidx.annotation.RequiresApi
 import androidx.annotation.RequiresPermission
 import com.facebook.jni.HybridData
@@ -19,6 +20,7 @@ import com.swmansion.audioapi.system.MediaSessionManager
 import com.swmansion.audioapi.system.NativeFileInfo
 import com.swmansion.audioapi.system.PermissionRequestListener
 import java.lang.ref.WeakReference
+import kotlin.concurrent.thread
 
 @OptIn(FrameworkAPI::class)
 @ReactModule(name = AudioAPIModule.NAME)
@@ -28,6 +30,7 @@ class AudioAPIModule(
   LifecycleEventListener {
   companion object {
     const val NAME = NativeAudioAPIModuleSpec.NAME
+    private const val TAG = "AudioAPIModule"
   }
 
   val reactContext: WeakReference<ReactApplicationContext> = WeakReference(reactContext)
@@ -257,21 +260,47 @@ class AudioAPIModule(
     }
   }
 
-  override fun resolveAndroidReleaseAsset(assetPath: String?): String? {
-    val context = reactContext.get() ?: return null
+  override fun readAndroidReleaseAssetBytesAsBase64(
+    assetPath: String?,
+    promise: Promise?,
+  ) {
+    if (assetPath.isNullOrBlank()) {
+      promise?.reject("E_INVALID_ASSET", "Asset path is empty", null)
+      return
+    }
+    val appContext = reactContext.get()?.applicationContext
+    if (appContext == null) {
+      promise?.reject("E_NO_CONTEXT", "React context unavailable", null)
+      return
+    }
+    thread(name = "rnaa-read-release-asset") {
+      try {
+        val bytes = readAndroidBundledAssetBytes(appContext, assetPath)
+        if (bytes == null || bytes.isEmpty()) {
+          promise?.reject("E_READ_ASSET", "Could not read asset bytes", null)
+          return@thread
+        }
+        promise?.resolve(Base64.encodeToString(bytes, Base64.NO_WRAP))
+      } catch (e: Exception) {
+        promise?.reject("E_READ_ASSET", e.message, e)
+      }
+    }
+  }
+
+  private fun readAndroidBundledAssetBytes(
+    context: android.content.Context,
+    assetPath: String,
+  ): ByteArray? {
     val packageName = context.packageName
 
-    val resourceId =
-      context.resources.getIdentifier(
-        assetPath,
-        "raw",
-        packageName,
-      )
-
-    return if (resourceId != 0) {
-      "android.resource://$packageName/$resourceId"
-    } else {
-      null
+    var resId = context.resources.getIdentifier(assetPath, "raw", packageName)
+    if (resId == 0 && assetPath.contains('.')) {
+      val nameWithoutExt = assetPath.substringBeforeLast('.')
+      resId = context.resources.getIdentifier(nameWithoutExt, "raw", packageName)
     }
+    if (resId != 0) {
+      context.resources.openRawResource(resId).use { return it.readBytes() }
+    }
+    return null
   }
 }

--- a/packages/react-native-audio-api/android/src/oldarch/NativeAudioAPIModuleSpec.java
+++ b/packages/react-native-audio-api/android/src/oldarch/NativeAudioAPIModuleSpec.java
@@ -21,6 +21,7 @@ import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.turbomodule.core.interfaces.TurboModule;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 public abstract class NativeAudioAPIModuleSpec extends ReactContextBaseJavaModule implements TurboModule {
   public static final String NAME = "AudioAPIModule";
@@ -101,4 +102,12 @@ public abstract class NativeAudioAPIModuleSpec extends ReactContextBaseJavaModul
   @ReactMethod
   @DoNotStrip
   public abstract void isNotificationActive(String key, Promise promise);
+
+  @ReactMethod(isBlockingSynchronousMethod = true)
+  @DoNotStrip
+  public abstract @Nullable String resolveAndroidReleaseAsset(String assetPath);
+
+  @ReactMethod
+  @DoNotStrip
+  public abstract void readAndroidReleaseAssetBytesAsBase64(String assetPath, Promise promise);
 }

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioFileSourceNode.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioFileSourceNode.cpp
@@ -112,6 +112,8 @@ void AudioFileSourceNode::initDecoders(
   decoderState_ = state;
   channelCount_ = decoderState_->channels;
   sampleRate_ = decoderState_->sampleRate;
+  audioBuffer_ = std::make_shared<DSPAudioBuffer>(
+      static_cast<size_t>(RENDER_QUANTUM_SIZE), channelCount_, context->getSampleRate());
 }
 
 void AudioFileSourceNode::start(double when) {

--- a/packages/react-native-audio-api/ios/audioapi/ios/AudioAPIModule.mm
+++ b/packages/react-native-audio-api/ios/audioapi/ios/AudioAPIModule.mm
@@ -130,6 +130,13 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(resolveAndroidReleaseAsset : (NSString *)
 }
 
 RCT_EXPORT_METHOD(
+    readAndroidReleaseAssetBytesAsBase64 : (NSString *)assetPath resolve : (RCTPromiseResolveBlock)
+        resolve reject : (RCTPromiseRejectBlock)reject)
+{
+  reject(@"E_PLATFORM", @"readAndroidReleaseAssetBytesAsBase64 is only available on Android", nil);
+}
+
+RCT_EXPORT_METHOD(
     setAudioSessionActivity : (BOOL)enabled resolve : (RCTPromiseResolveBlock)
         resolve reject : (RCTPromiseRejectBlock)reject)
 {

--- a/packages/react-native-audio-api/src/core/AudioDecoder.ts
+++ b/packages/react-native-audio-api/src/core/AudioDecoder.ts
@@ -9,6 +9,7 @@ import {
   isDataBlobString,
   isRemoteSource,
 } from '../utils/paths';
+import { base64ToArrayBuffer } from '../utils';
 import AudioBuffer from './AudioBuffer';
 
 class AudioDecoder {
@@ -88,22 +89,9 @@ class AudioDecoder {
   }
 
   private resolveLocalFilePath(stringSource: string): string {
-    let filePath = stringSource.startsWith('file://')
+    const filePath = stringSource.startsWith('file://')
       ? stringSource.replace('file://', '')
       : stringSource;
-
-    if (
-      Platform.OS === 'android' &&
-      !__DEV__ &&
-      !stringSource.startsWith('file://')
-    ) {
-      filePath = NativeAudioAPIModule.resolveAndroidReleaseAsset(filePath);
-      if (!filePath) {
-        throw new AudioApiError(
-          'Failed to resolve asset for android release build.'
-        );
-      }
-    }
 
     return filePath;
   }
@@ -112,6 +100,22 @@ class AudioDecoder {
     stringSource: string,
     sampleRate: number
   ): Promise<AudioBuffer> {
+    const useAndroidBundledAssetReader =
+      Platform.OS === 'android' &&
+      !stringSource.startsWith('file://') &&
+      !__DEV__;
+
+    // special workaround, because android bundled assets are passed as f.e. asset_example_file
+    // which has to be handled on native side and extension is not passed with it so decode using memory
+    if (useAndroidBundledAssetReader) {
+      const base64Payload =
+        await NativeAudioAPIModule.readAndroidReleaseAssetBytesAsBase64(
+          stringSource
+        );
+      const arrayBuffer = base64ToArrayBuffer(base64Payload);
+      return this.decodeFromArrayBuffer(arrayBuffer, sampleRate);
+    }
+
     const filePath = this.resolveLocalFilePath(stringSource);
     const buffer = await this.decoder.decodeWithFilePath(filePath, sampleRate);
     return new AudioBuffer(buffer);

--- a/packages/react-native-audio-api/src/core/AudioDecoder.ts
+++ b/packages/react-native-audio-api/src/core/AudioDecoder.ts
@@ -89,11 +89,9 @@ class AudioDecoder {
   }
 
   private resolveLocalFilePath(stringSource: string): string {
-    const filePath = stringSource.startsWith('file://')
+    return stringSource.startsWith('file://')
       ? stringSource.replace('file://', '')
       : stringSource;
-
-    return filePath;
   }
 
   private async decodeFromLocalFile(

--- a/packages/react-native-audio-api/src/development/react/Audio/Audio.tsx
+++ b/packages/react-native-audio-api/src/development/react/Audio/Audio.tsx
@@ -20,6 +20,7 @@ import { useStableAudioProps } from './utils';
 import { NotSupportedError } from '../../../errors';
 import { NativeAudioAPIModule } from '../../../specs';
 import { AudioControls } from '..';
+import { base64ToArrayBuffer } from '../../../utils';
 
 const Audio = React.forwardRef<AudioTagHandle, AudioProps>((props, ref) => {
   const { children } = props;
@@ -55,9 +56,6 @@ const Audio = React.forwardRef<AudioTagHandle, AudioProps>((props, ref) => {
     if (typeof source === 'string') {
       if (source.startsWith('file://') || source.startsWith('http')) {
         return source;
-      }
-      if (Platform.OS === 'android' && !__DEV__) {
-        return NativeAudioAPIModule.resolveAndroidReleaseAsset(source);
       }
       return source;
     }
@@ -181,20 +179,33 @@ const Audio = React.forwardRef<AudioTagHandle, AudioProps>((props, ref) => {
       setReady(false);
       onLoadStart();
       try {
-        if (path.startsWith('http')) {
-          const arrayBuffer = await fetch(path, {
-            headers:
-              typeof source === 'object' && source && 'headers' in source
-                ? source.headers
-                : undefined,
-          }).then((response) => response.arrayBuffer());
-
-          if (isCancelled) {
-            return;
-          }
+        if (
+          Platform.OS === 'android' &&
+          !__DEV__ &&
+          !path.startsWith('file://')
+        ) {
+          const base64Payload =
+            await NativeAudioAPIModule.readAndroidReleaseAssetBytesAsBase64(
+              path
+            );
+          const arrayBuffer = base64ToArrayBuffer(base64Payload);
           sourceRef.current = arrayBuffer;
         } else {
-          sourceRef.current = path;
+          if (path.startsWith('http')) {
+            const arrayBuffer = await fetch(path, {
+              headers:
+                typeof source === 'object' && source && 'headers' in source
+                  ? source.headers
+                  : undefined,
+            }).then((response) => response.arrayBuffer());
+
+            if (isCancelled) {
+              return;
+            }
+            sourceRef.current = arrayBuffer;
+          } else {
+            sourceRef.current = path;
+          }
         }
 
         if (!isCancelled) {

--- a/packages/react-native-audio-api/src/development/react/Audio/Audio.tsx
+++ b/packages/react-native-audio-api/src/development/react/Audio/Audio.tsx
@@ -200,6 +200,8 @@ const Audio = React.forwardRef<AudioTagHandle, AudioProps>((props, ref) => {
               return;
             }
             sourceRef.current = arrayBuffer;
+          } else if (path.startsWith('file://')) {
+            sourceRef.current = path.replace('file://', '');
           } else {
             sourceRef.current = path;
           }

--- a/packages/react-native-audio-api/src/development/react/Audio/Audio.tsx
+++ b/packages/react-native-audio-api/src/development/react/Audio/Audio.tsx
@@ -54,9 +54,6 @@ const Audio = React.forwardRef<AudioTagHandle, AudioProps>((props, ref) => {
       return '';
     }
     if (typeof source === 'string') {
-      if (source.startsWith('file://') || source.startsWith('http')) {
-        return source;
-      }
       return source;
     }
     // number

--- a/packages/react-native-audio-api/src/specs/NativeAudioAPIModule.ts
+++ b/packages/react-native-audio-api/src/specs/NativeAudioAPIModule.ts
@@ -50,7 +50,8 @@ interface Spec extends TurboModule {
   ): Promise<NotificationOpResponse>;
   hideNotification(key: string): Promise<NotificationOpResponse>;
   isNotificationActive(key: string): Promise<boolean>;
-  resolveAndroidReleaseAsset(assetPath: string): string;
+  // Android-only: reads bundled asset bytes and returns a Base64 string.
+  readAndroidReleaseAssetBytesAsBase64(assetPath: string): Promise<string>;
 }
 
 const NativeAudioAPIModule = TurboModuleRegistry.get<Spec>('AudioAPIModule')!;

--- a/packages/react-native-audio-api/src/specs/NativeAudioAPIModule.web.ts
+++ b/packages/react-native-audio-api/src/specs/NativeAudioAPIModule.web.ts
@@ -50,6 +50,7 @@ interface Spec extends TurboModule {
   ): Promise<NotificationOpResponse>;
   hideNotification(key: string): Promise<NotificationOpResponse>;
   isNotificationActive(key: string): Promise<boolean>;
+  readAndroidReleaseAssetBytesAsBase64(assetPath: string): Promise<string>;
 }
 
 const mockAsync =
@@ -84,6 +85,10 @@ const NativeAudioAPIModule: Spec = {
   showNotification: mockAsync({ success: true }),
   hideNotification: mockAsync({ success: true }),
   isNotificationActive: mockAsync(false),
+  readAndroidReleaseAssetBytesAsBase64: () =>
+    Promise.reject(
+      new Error('readAndroidReleaseAssetBytesAsBase64 is not supported on web')
+    ),
 };
 
 export { NativeAudioAPIModule };

--- a/packages/react-native-audio-api/src/utils/index.ts
+++ b/packages/react-native-audio-api/src/utils/index.ts
@@ -19,3 +19,13 @@ export function assertWorkletsEnabled() {
 export function clamp(value: number, min: number, max: number): number {
   return Math.min(Math.max(value, min), max);
 }
+
+export function base64ToArrayBuffer(base64: string): ArrayBuffer {
+  const binaryString = globalThis.atob(base64);
+  const len = binaryString.length;
+  const bytes = new Uint8Array(len);
+  for (let i = 0; i < len; i++) {
+    bytes[i] = binaryString.charCodeAt(i);
+  }
+  return bytes.buffer;
+}


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## ⚠️ Breaking changes ⚠️

<!-- A brief description of the breaking changes -->

-

## Introduced changes

<!-- A brief description of the changes -->

- in this implementation assets are decoded as memory block in android release mode, because `resolveAssetSource` works differently in android release mode
- `AudioFileSourceNode` now uses correct channel count

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added/Conducted relevant tests
- [ ] Performed self-review of the code
- [ ] Updated Web Audio API coverage
- [ ] Added support for web
- [ ] Updated old arch android spec file
