### PR TITLE
fix(cpp): add missing <cstddef> include in Constants.h

### DIFF
--- a/packages/react-native-audio-api/common/cpp/audioapi/core/utils/Constants.h
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/utils/Constants.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cmath>
+#include <cstddef>
 #include <limits>
 #include <new>
 #include <numbers>
@@ -10,7 +11,7 @@
 namespace audioapi {
 // audio
 inline constexpr int RENDER_QUANTUM_SIZE = 128;
-inline constexpr size_t MAX_FFT_SIZE = 32768;
+inline constexpr std::size_t MAX_FFT_SIZE = 32768;
 inline constexpr int MAX_CHANNEL_COUNT = 32;
 inline constexpr float DEFAULT_SAMPLE_RATE = 44100.0f;
 inline constexpr int OCTAVE_RANGE = 1200;
@@ -32,9 +33,9 @@ inline const float LOG10_MOST_POSITIVE_SINGLE_FLOAT = std::log10(MOST_POSITIVE_S
 inline constexpr float PI = std::numbers::pi_v<float>;
 
 // buffer sizes
-inline constexpr size_t PROMISE_VENDOR_THREAD_POOL_WORKER_COUNT = 4;
-inline constexpr size_t PROMISE_VENDOR_THREAD_POOL_LOAD_BALANCER_QUEUE_SIZE = 32;
-inline constexpr size_t PROMISE_VENDOR_THREAD_POOL_WORKER_QUEUE_SIZE = 32;
+inline constexpr std::size_t PROMISE_VENDOR_THREAD_POOL_WORKER_COUNT = 4;
+inline constexpr std::size_t PROMISE_VENDOR_THREAD_POOL_LOAD_BALANCER_QUEUE_SIZE = 32;
+inline constexpr std::size_t PROMISE_VENDOR_THREAD_POOL_WORKER_QUEUE_SIZE = 32;
 
 // Cache line size
 #ifdef __cpp_lib_hardware_interference_size
@@ -46,5 +47,5 @@ constexpr std::size_t hardware_destructive_interference_size = 64;
 #endif
 
 // audio param
-inline constexpr size_t AUDIO_PARAM_MAX_QUEUED_EVENTS = 64;
+inline constexpr std::size_t AUDIO_PARAM_MAX_QUEUED_EVENTS = 64;
 } // namespace audioapi


### PR DESCRIPTION
## Summary

`common/cpp/audioapi/core/utils/Constants.h` declares several `size_t` constants at global/`std::` scope but only includes `<cmath>`, `<limits>`, `<new>`, and `<numbers>`. None of those headers is required by the C++ standard to expose `size_t`. Older libc++ versions shipped by Apple transitively dragged in `<stddef.h>` through internal includes, so the header \"just worked\", but libc++ on Xcode 26.4+ has tightened header isolation and the transitive exposure is gone.

With Xcode 26.4+ the pod now fails to compile:

```
ios/Pods/Headers/Private/RNAudioAPI/audioapi/core/Constants.h:11:18
> static constexpr size_t MAX_FFT_SIZE = 32768;
                    ^ unknown type name 'size_t'; did you mean 'std::size_t'?
```

The fix is to include `<cstddef>` (which is standard-guaranteed to provide `std::size_t`) and switch the remaining bare `size_t` usages to `std::size_t`, matching the file's existing style (`std::numeric_limits`, `std::log2`, and `std::size_t` in the hardware-interference block).

## Reproducer

Any iOS build with Xcode 26.4+ against a project consuming `react-native-audio-api` — we hit it on Xcode 26.4.1 with `0.8.4` and confirmed the same source issue is present in `0.11.4` through `0.12.0` / latest `main`.

## Note on other files

`grep` finds ~25 other headers in this package that use bare `size_t` without including `<cstddef>` / `<stddef.h>` — they compile today only because their translation units transitively include something like `<string>` or `<vector>` first. They'll bite the next time a header-ordering change exposes them. Happy to send a follow-up PR making the includes explicit across the board if you'd prefer; this PR deliberately only fixes the one file that actually fails to compile on Xcode 26.4+.

## Test plan
- [ ] `pod install && xcodebuild` for an app consuming this package on Xcode 26.4+ — Constants.h now compiles cleanly.
- [ ] Existing CI on older Xcode stays green (no API changes, just include + consistent namespacing).