### PR TITLE
fix: output buff instead of input

### DIFF
--- a/packages/react-native-audio-api/common/cpp/audioapi/core/effects/WorkletProcessingNode.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/effects/WorkletProcessingNode.cpp
@@ -71,7 +71,7 @@ std::shared_ptr<DSPAudioBuffer> WorkletProcessingNode::processNode(
 
     if (result.has_value()) {
       // Copy processed output data
-      channelData->copy(*inputBuffsHandles_[ch], 0, 0, framesToProcess);
+      channelData->copy(*outputBuffsHandles_[ch], 0, 0, framesToProcess);
     } else {
       // Zero the output on worklet execution failure
       channelData->zero(0, framesToProcess);


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## ⚠️ Breaking changes ⚠️

<!-- A brief description of the breaking changes -->

-

## Introduced changes

<!-- A brief description of the changes -->

- copying output instead of input to processing buffer in `WorkletProcessingNode`

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added/Conducted relevant tests
- [ ] Performed self-review of the code
- [ ] Updated Web Audio API coverage
- [ ] Added support for web
- [ ] Updated old arch android spec file
