### PR TITLE
fix: restore react-native-worklets as an optional peer dep

### DIFF
--- a/packages/react-native-audio-api/package.json
+++ b/packages/react-native-audio-api/package.json
@@ -98,7 +98,13 @@
   },
   "peerDependencies": {
     "react": "*",
-    "react-native": "*"
+    "react-native": "*",
+    "react-native-worklets": ">= 0.6.0"
+  },
+  "peerDependenciesMeta": {
+    "react-native-worklets": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@babel/cli": "^7.20.0",

--- a/packages/react-native-audio-api/scripts/validate-worklets-version.js
+++ b/packages/react-native-audio-api/scripts/validate-worklets-version.js
@@ -23,7 +23,7 @@ function validateVersion() {
 
 if (!validateVersion()) {
   console.warn(
-    '[RNAudioApi] Incompatible version of react-native-audio-worklets detected. Please install a compatible version if you want to use worklet nodes in react-native-audio-api.'
+    '[RNAudioApi] Incompatible version of react-native-worklets detected. Please install a compatible version if you want to use worklet nodes in react-native-audio-api.'
   );
   process.exit(1);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10895,6 +10895,10 @@ __metadata:
   peerDependencies:
     react: "*"
     react-native: "*"
+    react-native-worklets: ">= 0.6.0"
+  peerDependenciesMeta:
+    react-native-worklets:
+      optional: true
   bin:
     setup-rn-audio-api-web: ./scripts/setup-rn-audio-api-web.js
   languageName: unknown


### PR DESCRIPTION
## ⚠️ Breaking changes ⚠️

<!-- A brief description of the breaking changes -->

None at runtime.

This does slightly change install-time signaling: package managers may now show an advisory optional-peer message when `react-native-worklets` is not installed directly. That matches `react-native-audio-api` in `v0.10.1`.

## Introduced changes

<!-- A brief description of the changes -->

- restore `react-native-worklets` as an optional peer dependency with version range `>= 0.6.0`
- fix a typo in `scripts/validate-worklets-version.js` where the warning referenced `react-native-audio-worklets` instead of `react-native-worklets`

## Why

The iOS podspec still requires `RNWorklets` whenever node can resolve `react-native-worklets`.

But CocoaPods autolinking only sees packages declared directly in the consumer app. So when `react-native-worklets` is only present transitively (for example via `pressto`), consumers can hit:

`Unable to find a specification for RNWorklets`

during `pod install`, with no package-level hint that `react-native-worklets` is expected as a direct dependency.

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added/Conducted relevant tests
- [x] Performed self-review of the code
- [ ] Updated Web Audio API coverage
- [ ] Added support for web
- [ ] Updated old arch android spec file
