### PR TITLE
Fix Android build with FFmpeg disabled

### DIFF
--- a/packages/react-native-audio-api/android/src/main/cpp/audioapi/android/core/AndroidAudioRecorder.cpp
+++ b/packages/react-native-audio-api/android/src/main/cpp/audioapi/android/core/AndroidAudioRecorder.cpp
@@ -321,7 +321,7 @@ Result<NoneType, std::string> AndroidAudioRecorder::setupFileWriter(
     const std::string &fileNameOverride) {
 #if RN_AUDIO_API_FFMPEG_DISABLED
   if (properties->format != AudioFileProperties::Format::WAV) {
-    return Result<std::string, std::string>::Err(
+    return Result<NoneType, std::string>::Err(
         "FFmpeg backend is disabled. Cannot create file writer for the requested format. Use WAV format instead.");
   }
 #endif


### PR DESCRIPTION
## Introduced changes

There was a compiler error on Android with ffmpeg disabled:
```
AndroidAudioRecorder.cpp:324:12: error: no viable conversion from returned value of
type 'Result<std::string, [...]>' to function return type 'Result<NoneType, [...]>'
  324 |     return Result<std::string, std::string>::Err(
      |            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  325 |         "FFmpeg backend is disabled. Cannot create file writer for the requested
      |         format. Use WAV format instead.");
```

Fortunately it's a one-liner fix

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added/Conducted relevant tests
- [x] Performed self-review of the code
- [x] Updated Web Audio API coverage
- [x] Added support for web
- [x] Updated old arch android spec file
