### PR TITLE
fix: prebuilt binaries to 3.1

### DIFF
--- a/apps/fabric-example/ios/Podfile.lock
+++ b/apps/fabric-example/ios/Podfile.lock
@@ -2550,7 +2550,7 @@ SPEC CHECKSUMS:
   ReactCodegen: d07ee3c8db75b43d1cbe479ae6affebf9925c733
   ReactCommon: fe2a3af8975e63efa60f95fca8c34dc85deee360
   ReactNativeDependencies: 4d5ce2683b6d74f7c686bf90a88c7d381295cf3c
-  RNAudioAPI: a36dcdaa5905d2b0e1f7170f7b5cb3cec944c029
+  RNAudioAPI: 0da654a83adfff638b0ccf05f7b07869a8e78cbe
   RNGestureHandler: 187c5c7936abf427bc4d22d6c3b1ac80ad1f63c0
   RNReanimated: 64f4b3b33b48b19e0ba76a352571b52b1e931981
   RNScreens: 01b065ded2dfe7987bcce770ff3a196be417ff41

--- a/packages/react-native-audio-api/RNAudioAPI.podspec
+++ b/packages/react-native-audio-api/RNAudioAPI.podspec
@@ -131,8 +131,6 @@ Pod::Spec.new do |s|
       -force_load #{lib_dir}/libvorbis.a
       -force_load #{lib_dir}/libvorbisenc.a
       -force_load #{lib_dir}/libvorbisfile.a
-      -force_load #{lib_dir}/libssl.a
-      -force_load #{lib_dir}/libcrypto.a
     ].join(" "),
   }
   # Use install_modules_dependencies helper to install the dependencies if React Native version >=0.71.0.

--- a/packages/react-native-audio-api/android/src/main/cpp/audioapi/CMakeLists.txt
+++ b/packages/react-native-audio-api/android/src/main/cpp/audioapi/CMakeLists.txt
@@ -123,6 +123,11 @@ if (RN_AUDIO_API_FFMPEG_DISABLED)
   )
 endif()
 
+target_compile_definitions(
+  react-native-audio-api
+  PRIVATE $<$<CONFIG:Debug>:DEBUG>
+)
+
 target_link_libraries(react-native-audio-api
   ${LINK_LIBRARIES}
   ${RN_VERSION_LINK_LIBRARIES}

--- a/packages/react-native-audio-api/android/src/main/cpp/audioapi/CMakeLists.txt
+++ b/packages/react-native-audio-api/android/src/main/cpp/audioapi/CMakeLists.txt
@@ -123,11 +123,6 @@ if (RN_AUDIO_API_FFMPEG_DISABLED)
   )
 endif()
 
-target_compile_definitions(
-  react-native-audio-api
-  PRIVATE $<$<CONFIG:Debug>:DEBUG>
-)
-
 target_link_libraries(react-native-audio-api
   ${LINK_LIBRARIES}
   ${RN_VERSION_LINK_LIBRARIES}
@@ -137,8 +132,6 @@ target_link_libraries(react-native-audio-api
   vorbis
   vorbisenc
   vorbisfile
-  crypto
-  ssl
   z
 )
 

--- a/packages/react-native-audio-api/android/src/main/cpp/audioapi/android/core/AndroidAudioRecorder.cpp
+++ b/packages/react-native-audio-api/android/src/main/cpp/audioapi/android/core/AndroidAudioRecorder.cpp
@@ -578,7 +578,7 @@ void AndroidAudioRecorder::onErrorAfterClose(oboe::AudioStream *stream, oboe::Re
       audioEventHandlerRegistry_->dispatchEvent(
           AudioEvent::RECORDER_ERROR,
           callbackId,
-          RecorderErrorPayload{.message = std::move(message)});
+          StringPayload{.name = "message", .reason = std::move(message)});
       return;
     }
 

--- a/packages/react-native-audio-api/scripts/download-prebuilt-binaries.sh
+++ b/packages/react-native-audio-api/scripts/download-prebuilt-binaries.sh
@@ -2,7 +2,7 @@
 # Script to download and unzip prebuilt native binaries for React Native.
 
 MAIN_DOWNLOAD_URL="https://github.com/software-mansion-labs/rn-audio-libs/releases/download"
-TAG="v3.0.0"
+TAG="v3.1.0"
 DOWNLOAD_NAMES=(
     "android.zip"
     "ffmpeg_ios.zip"


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## ⚠️ Breaking changes ⚠️

<!-- A brief description of the breaking changes -->

-

## Introduced changes

<!-- A brief description of the changes -->

- ffmpeg was already compiled with openssl and libcrypto so there is no need to download them and link them against our code

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added/Conducted relevant tests
- [ ] Performed self-review of the code
- [ ] Updated Web Audio API coverage
- [ ] Added support for web
- [ ] Updated old arch android spec file
