### PR TITLE
fix(queue-source): clamp src-channel index in processWithInterpolation

### DIFF
--- a/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioBufferQueueSourceNode.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioBufferQueueSourceNode.cpp
@@ -252,12 +252,22 @@ void AudioBufferQueueSourceNode::processWithInterpolation(
         }
       }
 
+      // Source-channel index is clamped to the buffer's last channel so a
+      // mono buffer feeding a stereo destination is duplicated across the
+      // output channels (matches Web Audio's mono→stereo upmix). Without
+      // the clamp, `getChannel(i)` for `i >= srcChannels` walked past the
+      // channels_ vector and aborted the audio render thread on a mono
+      // queue at non-1.0 playback rates.
+      const size_t srcChannels = buffer->getNumberOfChannels();
+      const size_t nextSrcChannels = crossBufferInterpolation ? nextBuffer->getNumberOfChannels() : srcChannels;
       for (size_t i = 0; i < processingBuffer->getNumberOfChannels(); i += 1) {
         const auto destination = processingBuffer->getChannel(i)->span();
-        const auto currentSource = buffer->getChannel(i)->span();
+        const auto currentSource =
+            buffer->getChannel(std::min(i, srcChannels - 1))->span();
 
         if (crossBufferInterpolation) {
-          const auto nextSource = nextBuffer->getChannel(i)->span();
+          const auto nextSource =
+              nextBuffer->getChannel(std::min(i, nextSrcChannels - 1))->span();
           float currentSample = currentSource[readIndex];
           float nextSample = nextSource[nextReadIndex];
           destination[writeIndex] = currentSample + factor * (nextSample - currentSample);


### PR DESCRIPTION
## Summary

`AudioBufferQueueSourceNode::processWithInterpolation` loops `i = 0..processingBuffer.numberOfChannels` and indexes `buffer->getChannel(i)` without checking the source buffer's channel count. Enqueueing a mono buffer with `playbackRate != 1.0` (e.g. for sample-rate compensation) walks past `channels_.size()`, hits the `std::vector::operator[]` debug assert, and aborts the audio render thread (`SIGABRT` in `AURemoteIO::IOThread`).

`processWithoutInterpolation` doesn't have this issue — it delegates to `DSPAudioBuffer::copy`, which handles up/down-mixing. Anything that pushes the queue source through the interpolation path (any non-1.0 `playbackRate`, including sample-rate compensation tricks) hits the bug.

## Fix

Clamp the source-channel index to `std::min(i, srcChannels - 1)`. For a mono source feeding a stereo destination this duplicates the mono channel into both output channels — matches Web Audio's mono→stereo upmix semantics. The same clamp is applied to `nextBuffer` for cross-buffer interpolation.

This is the minimum fix to stop the crash. Spec-compliant downmix (e.g. stereo→mono averaging) for source channels greater than destination would still fall through to a discrete take-channel-N — that's a separate, existing limitation worth a follow-up. The non-interpolation path already gets full mixing via `DSPAudioBuffer::copy`; bringing the interpolation path up to parity (process into a temp source-shaped buffer, then `copy()` into the destination) would be the right long-term move.

## Reproduction

```ts
const ctx = new AudioContext({ sampleRate: 48000 })
const queue = ctx.createBufferQueueSource()
queue.playbackRate.value = 0.5 // forces processWithInterpolation
queue.connect(ctx.destination)

const buf = ctx.createBuffer(1, 2400, 24000) // mono buffer
buf.getChannelData(0).set(new Float32Array(2400).fill(0.1))
queue.enqueueBuffer(buf)
queue.start()
// → SIGABRT on the audio render thread within ~one render quantum
```

Stack of the abort (iOS simulator, debug build):

```
__pthread_kill
abort
std::vector<...AudioArray...>::operator[]
audioapi::AudioBus::getChannel(int) const
audioapi::AudioBufferQueueSourceNode::processWithInterpolation   <-- here
audioapi::AudioBufferBaseSourceNode::processWithoutPitchCorrection
audioapi::AudioBufferQueueSourceNode::processNode
audioapi::AudioNode::processAudio
... AudioDestinationNode -> AVAudioEngine -> AURemoteIO::IOThread
```

Hit in the wild streaming Kokoro TTS PCM (mono, 24 kHz) into the queue source on a 48 kHz iOS context with `playbackRate = 24000/48000 = 0.5` for sample-rate compensation. The streaming use-case is the natural fit for the queue source, and PCM streams are very often mono — combined with the default-2-channel destination, this crash is easy to trip.

## Test plan

- [ ] Verify build still succeeds on iOS / Android
- [ ] Repro snippet above no longer crashes; mono → stereo audibly plays back through both output channels
- [ ] Stereo source / stereo destination still behaves identically (no perf regression — the clamp is a no-op in the matching-channel-count case)
- [ ] Existing test suite passes