### PR TITLE
fix: proper channel count in queue buffer source node

### DIFF
--- a/apps/fabric-example/ios/Podfile.lock
+++ b/apps/fabric-example/ios/Podfile.lock
@@ -2476,7 +2476,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   FBLazyVector: c00c20551d40126351a6783c47ce75f5b374851b
-  hermes-engine: c399a2e224a0b13c589d76b4fc05e14bdd76fa88
+  hermes-engine: 91023181d4bc5948b457de5314623fbfe4f8604e
   RCTDeprecation: 3bb167081b134461cfeb875ff7ae1945f8635257
   RCTRequired: 74839f55d5058a133a0bc4569b0afec750957f64
   RCTSwiftUI: 87a316382f3eab4dd13d2a0d0fd2adcce917361a
@@ -2485,7 +2485,7 @@ SPEC CHECKSUMS:
   React: 1b1536b9099195944034e65b1830f463caaa8390
   React-callinvoker: 6dff6d17d1d6cc8fdf85468a649bafed473c65f5
   React-Core: 00faa4d038298089a1d5a5b21dde8660c4f0820d
-  React-Core-prebuilt: ab26be1216323aea7c76f96ca450bffa7bcd4a72
+  React-Core-prebuilt: a6d614de037caff7898424dfc22915ec792de921
   React-CoreModules: a17807f849bfd86045b0b9a75ec8c19373b482f6
   React-cxxreact: c7b53ace5827be54048288bce5c55f337c41e95f
   React-debug: e1f00fcd2cef58a2897471a6d76a4ef5f5f90c74
@@ -2549,8 +2549,8 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 5787b37b8e2e51dfeab697ec031cc7c4080dcea2
   ReactCodegen: d07ee3c8db75b43d1cbe479ae6affebf9925c733
   ReactCommon: fe2a3af8975e63efa60f95fca8c34dc85deee360
-  ReactNativeDependencies: 212738cc51e6c4cc34ee487890497d6f41979ec0
-  RNAudioAPI: a36dcdaa5905d2b0e1f7170f7b5cb3cec944c029
+  ReactNativeDependencies: 4d5ce2683b6d74f7c686bf90a88c7d381295cf3c
+  RNAudioAPI: 0da654a83adfff638b0ccf05f7b07869a8e78cbe
   RNGestureHandler: 187c5c7936abf427bc4d22d6c3b1ac80ad1f63c0
   RNReanimated: 64f4b3b33b48b19e0ba76a352571b52b1e931981
   RNScreens: 01b065ded2dfe7987bcce770ff3a196be417ff41

--- a/packages/react-native-audio-api/common/cpp/audioapi/HostObjects/sources/AudioBufferQueueSourceNodeHostObject.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/HostObjects/sources/AudioBufferQueueSourceNodeHostObject.cpp
@@ -106,7 +106,7 @@ JSI_HOST_FUNCTION_IMPL(AudioBufferQueueSourceNodeHostObject, enqueueBuffer) {
                 swapBuffer,
                 channelCount = channelCount_](BaseAudioContext &) {
     if (swapBuffer) {
-      audioBufferQueueSourceNode->setChannelCount(channelCount);
+      audioBufferQueueSourceNode->setChannelCount(static_cast<int>(channelCount));
     }
     audioBufferQueueSourceNode->enqueueBuffer(copiedBuffer, bufferId, tailBuffer);
   };

--- a/packages/react-native-audio-api/common/cpp/audioapi/HostObjects/sources/AudioBufferQueueSourceNodeHostObject.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/HostObjects/sources/AudioBufferQueueSourceNodeHostObject.cpp
@@ -68,9 +68,24 @@ JSI_HOST_FUNCTION_IMPL(AudioBufferQueueSourceNodeHostObject, enqueueBuffer) {
   auto audioBufferHostObject =
       args[0].getObject(runtime).asHostObject<AudioBufferHostObject>(runtime);
   // TODO: add optimized memory management for buffer changes, e.g.
-  //  when the same buffer is reused across threads and
+  // when the same buffer is reused across threads and
   // buffer modification is not allowed on JS thread
-  auto copiedBuffer = std::make_shared<AudioBuffer>(*audioBufferHostObject->audioBuffer_);
+
+  auto swapBuffer = false; // whether to swap internal node buffer with the new buffer
+  if (!channelCountSet_) {
+    channelCount_ = static_cast<int>(audioBufferHostObject->audioBuffer_->getNumberOfChannels());
+    channelCountSet_ = true;
+    swapBuffer = true;
+  }
+
+  // first buffer defines channel count, rest of them is mixed to channel count of the first buffer
+  auto copiedBuffer = std::make_shared<AudioBuffer>(
+      audioBufferHostObject->audioBuffer_->getSize(),
+      channelCount_,
+      audioBufferHostObject->audioBuffer_->getSampleRate());
+
+  copiedBuffer->sum(*audioBufferHostObject->audioBuffer_);
+
   std::shared_ptr<AudioBuffer> tailBuffer = nullptr;
 
   if (pitchCorrection_ && !stretchHasBeenInit_) {
@@ -84,8 +99,15 @@ JSI_HOST_FUNCTION_IMPL(AudioBufferQueueSourceNodeHostObject, enqueueBuffer) {
     stretchHasBeenInit_ = true;
   }
 
-  auto event = [audioBufferQueueSourceNode, copiedBuffer, bufferId = bufferId_, tailBuffer](
-                   BaseAudioContext &) {
+  auto event = [audioBufferQueueSourceNode,
+                copiedBuffer,
+                bufferId = bufferId_,
+                tailBuffer,
+                swapBuffer,
+                channelCount = channelCount_](BaseAudioContext &) {
+    if (swapBuffer) {
+      audioBufferQueueSourceNode->setChannelCount(channelCount);
+    }
     audioBufferQueueSourceNode->enqueueBuffer(copiedBuffer, bufferId, tailBuffer);
   };
   audioBufferQueueSourceNode->scheduleAudioEvent(std::move(event));

--- a/packages/react-native-audio-api/common/cpp/audioapi/HostObjects/sources/AudioBufferQueueSourceNodeHostObject.h
+++ b/packages/react-native-audio-api/common/cpp/audioapi/HostObjects/sources/AudioBufferQueueSourceNodeHostObject.h
@@ -30,6 +30,8 @@ class AudioBufferQueueSourceNodeHostObject : public AudioBufferBaseSourceNodeHos
   size_t bufferId_ = 0;
   uint64_t onBufferEndedCallbackId_ = 0;
   bool stretchHasBeenInit_ = false;
+  bool channelCountSet_ = false;
+  int channelCount_ = 0;
 
   void setOnBufferEndedCallbackId(uint64_t callbackId);
 };

--- a/packages/react-native-audio-api/common/cpp/audioapi/HostObjects/sources/AudioBufferQueueSourceNodeHostObject.h
+++ b/packages/react-native-audio-api/common/cpp/audioapi/HostObjects/sources/AudioBufferQueueSourceNodeHostObject.h
@@ -31,7 +31,6 @@ class AudioBufferQueueSourceNodeHostObject : public AudioBufferBaseSourceNodeHos
   uint64_t onBufferEndedCallbackId_ = 0;
   bool stretchHasBeenInit_ = false;
   bool channelCountSet_ = false;
-  int channelCount_ = 0;
 
   void setOnBufferEndedCallbackId(uint64_t callbackId);
 };

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioBufferQueueSourceNode.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioBufferQueueSourceNode.cpp
@@ -130,6 +130,14 @@ void AudioBufferQueueSourceNode::unregisterOnBufferEndedCallback(uint64_t callba
   audioEventHandlerRegistry_->unregisterHandler(AudioEvent::BUFFER_ENDED, callbackId);
 }
 
+void AudioBufferQueueSourceNode::setChannelCount(int channelCount) {
+  if (channelCount_ != channelCount) {
+    channelCount_ = channelCount;
+    audioBuffer_ = std::make_shared<DSPAudioBuffer>(
+        RENDER_QUANTUM_SIZE, channelCount_, getContextSampleRate());
+  }
+}
+
 double AudioBufferQueueSourceNode::getCurrentPosition() const {
   return dsp::sampleFrameToTime(static_cast<int>(vReadIndex_), getContextSampleRate()) +
       playedBuffersDuration_;

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioBufferQueueSourceNode.h
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioBufferQueueSourceNode.h
@@ -50,6 +50,7 @@ class AudioBufferQueueSourceNode : public AudioBufferBaseSourceNode {
 
   /// @brief Set the channel count of the node. Channel count is set only once when the first buffer is enqueued.
   /// @param channelCount The channel count to set.
+  /// @note Audio Thread only
   void setChannelCount(int channelCount);
 
  protected:

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioBufferQueueSourceNode.h
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioBufferQueueSourceNode.h
@@ -48,6 +48,10 @@ class AudioBufferQueueSourceNode : public AudioBufferBaseSourceNode {
 
   void unregisterOnBufferEndedCallback(uint64_t callbackId);
 
+  /// @brief Set the channel count of the node. Channel count is set only once when the first buffer is enqueued.
+  /// @param channelCount The channel count to set.
+  void setChannelCount(int channelCount);
+
  protected:
   double getCurrentPosition() const override;
 


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #1044 

## ⚠️ Breaking changes ⚠️

<!-- A brief description of the breaking changes -->

-

## Introduced changes

<!-- A brief description of the changes -->

- `AudioBufferQueueSourceNode` has channel count set upon first buffer enqueue method and it is respective to the buffer

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added/Conducted relevant tests
- [ ] Performed self-review of the code
- [ ] Updated Web Audio API coverage
- [ ] Added support for web
- [ ] Updated old arch android spec file
