### PR TITLE
fix: iOS recorder callback restart

### DIFF
--- a/apps/fabric-example/ios/FabricExampleTests/IOSAudioRecorderTests.mm
+++ b/apps/fabric-example/ios/FabricExampleTests/IOSAudioRecorderTests.mm
@@ -325,7 +325,6 @@ class TestableIOSAudioRecorder : public IOSAudioRecorder {
       "fabric-example-tests",
       "ios-recorder-test",
       2,
-      1,
       0,
       AudioFileProperties::Format::WAV,
       44100,
@@ -588,6 +587,22 @@ class TestableIOSAudioRecorder : public IOSAudioRecorder {
   XCTAssertTrue(_recorder->connectionEnabledIntent());
   XCTAssertFalse(_recorder->connectionConfigured());
   XCTAssertFalse(_recorder->isConnected());
+}
+
+- (void)testRestartAfterStopReusesConfiguredCallback
+{
+  self.audioEngine.state = AudioEngineStateRunning;
+  self.nativeRecorder.mockResolvedInputFormat = [self validMultichannelFormat];
+
+  XCTAssertTrue(_recorder->setOnAudioReadyCallback(48000, 256, 1, 99).is_ok());
+  XCTAssertTrue(_recorder->start("").is_ok());
+  XCTAssertTrue(_recorder->stop().is_ok());
+
+  auto restartResult = _recorder->start("");
+
+  XCTAssertTrue(restartResult.is_ok());
+  XCTAssertTrue(_recorder->callbackOutputEnabledIntent());
+  XCTAssertTrue(_recorder->callbackOutputConfigured());
 }
 
 - (void)testFileOutputSmokeTest

--- a/packages/react-native-audio-api/ios/audioapi/ios/core/IOSAudioRecorder.mm
+++ b/packages/react-native-audio-api/ios/audioapi/ios/core/IOSAudioRecorder.mm
@@ -322,7 +322,7 @@ Result<std::tuple<std::vector<std::string>, double, double>, std::string> IOSAud
 
     if (hadCallback) {
       callbackOutputConfigured_.store(false, std::memory_order_release);
-      dataCallback = std::move(dataCallback_);
+      dataCallback = dataCallback_;
     }
 
     if (hadConnection) {


### PR DESCRIPTION
## ⚠️ Breaking changes ⚠️

None

## Introduced changes

I noticed while testing recording on iOS that I got a `Failed to prepare callback: callback is unavailable` error when I stopped and started recording multiple times in a row. This PR fixes this error

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue (Sorry I didn't open an issue first, I can if needed)
- [ ] Updated relevant documentation (N/A)
- [x] Added/Conducted relevant tests
- [x] Performed self-review of the code
- [ ] Updated Web Audio API coverage (N/A)
- [ ] Added support for web (N/A)
- [ ] Updated old arch android spec file (N/A)
