### PR TITLE
fix(recorder): copy audio buffer before async handoff to fix use-after-free

### DIFF
--- a/packages/react-native-audio-api/android/src/main/cpp/audioapi/android/core/utils/AndroidRecorderCallback.cpp
+++ b/packages/react-native-audio-api/android/src/main/cpp/audioapi/android/core/utils/AndroidRecorderCallback.cpp
@@ -7,6 +7,7 @@
 #include <audioapi/utils/CircularArray.hpp>
 
 #include <algorithm>
+#include <cstring>
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -141,7 +142,18 @@ void AndroidRecorderCallback::receiveAudioData(void *data, int numFrames) {
     return;
   }
 
-  offloader_->getSender()->send({data, numFrames});
+  // Oboe owns `data` only for the duration of this synchronous callback.
+  // Copy into an owned buffer before handing off to the worker thread; the
+  // consumer in taskOffloaderFunction frees it.
+  size_t bytes =
+      static_cast<size_t>(numFrames) * streamChannelCount_ * ma_get_bytes_per_sample(ma_format_f32);
+  void *owned = ma_malloc(bytes, nullptr);
+  if (owned == nullptr) {
+    return;
+  }
+  std::memcpy(owned, data, bytes);
+
+  offloader_->getSender()->send({owned, numFrames});
 }
 
 /// @brief Deinterleaves the audio data and pushes it into the circular buffer.
@@ -160,6 +172,13 @@ void AndroidRecorderCallback::deinterleaveAndPushAudioData(void *data, int numFr
 /// processes it (resampling and deinterleaving if necessary), and pushes it into the circular buffer.
 void AndroidRecorderCallback::taskOffloaderFunction(CallbackData callbackData) {
   auto [data, numFrames] = callbackData;
+
+  // The TaskOffloader destructor sends a default-constructed CallbackData
+  // (data == nullptr) to unblock the receiver; ignore it here.
+  if (data == nullptr) {
+    return;
+  }
+
   ma_uint64 inputFrameCount = numFrames;
   ma_uint64 outputFrameCount = 0;
 
@@ -170,6 +189,7 @@ void AndroidRecorderCallback::taskOffloaderFunction(CallbackData callbackData) {
     if (circularBuffer_[0]->getNumberOfAvailableFrames() >= bufferLength_) {
       emitAudioData();
     }
+    ma_free(data, nullptr);
     return;
   }
 
@@ -184,6 +204,8 @@ void AndroidRecorderCallback::taskOffloaderFunction(CallbackData callbackData) {
   if (circularBuffer_[0]->getNumberOfAvailableFrames() >= bufferLength_) {
     emitAudioData();
   }
+
+  ma_free(data, nullptr);
 }
 
 } // namespace audioapi

--- a/packages/react-native-audio-api/android/src/main/cpp/audioapi/android/core/utils/AndroidRecorderCallback.cpp
+++ b/packages/react-native-audio-api/android/src/main/cpp/audioapi/android/core/utils/AndroidRecorderCallback.cpp
@@ -99,7 +99,7 @@ Result<NoneType, std::string> AndroidRecorderCallback::prepare(
 }
 
 void AndroidRecorderCallback::cleanup() {
-  std::scoped_lock(callbackMutex_);
+  std::scoped_lock lock(callbackMutex_);
   if (circularBuffer_[0]->getNumberOfAvailableFrames() > 0) {
     emitAudioData(true);
   }
@@ -166,7 +166,7 @@ void AndroidRecorderCallback::taskOffloaderFunction(CallbackData callbackData) {
   if (data == nullptr) {
     return;
   }
-  std::scoped_lock(callbackMutex_);
+  std::scoped_lock lock(callbackMutex_);
 
   ma_uint64 inputFrameCount = numFrames;
   ma_uint64 outputFrameCount = 0;

--- a/packages/react-native-audio-api/android/src/main/cpp/audioapi/android/core/utils/AndroidRecorderCallback.cpp
+++ b/packages/react-native-audio-api/android/src/main/cpp/audioapi/android/core/utils/AndroidRecorderCallback.cpp
@@ -36,20 +36,7 @@ AndroidRecorderCallback::AndroidRecorderCallback(
           callbackId) {}
 
 AndroidRecorderCallback::~AndroidRecorderCallback() {
-  if (converter_ != nullptr) {
-    ma_data_converter_uninit(converter_.get(), nullptr);
-    converter_.reset();
-  }
-
-  if (processingBuffer_ != nullptr) {
-    ma_free(processingBuffer_, nullptr);
-    processingBuffer_ = nullptr;
-    processingBufferLength_ = 0;
-  }
-
-  for (size_t i = 0; i < circularBuffer_.size(); ++i) {
-    circularBuffer_[i]->zero();
-  }
+  cleanup();
 }
 
 /// @brief Prepares the recorder callback by initializing the data converter and allocating necessary buffers.
@@ -112,6 +99,7 @@ Result<NoneType, std::string> AndroidRecorderCallback::prepare(
 }
 
 void AndroidRecorderCallback::cleanup() {
+  std::scoped_lock(callbackMutex_);
   if (circularBuffer_[0]->getNumberOfAvailableFrames() > 0) {
     emitAudioData(true);
   }
@@ -178,6 +166,7 @@ void AndroidRecorderCallback::taskOffloaderFunction(CallbackData callbackData) {
   if (data == nullptr) {
     return;
   }
+  std::scoped_lock(callbackMutex_);
 
   ma_uint64 inputFrameCount = numFrames;
   ma_uint64 outputFrameCount = 0;

--- a/packages/react-native-audio-api/android/src/main/cpp/audioapi/android/core/utils/AndroidRecorderCallback.h
+++ b/packages/react-native-audio-api/android/src/main/cpp/audioapi/android/core/utils/AndroidRecorderCallback.h
@@ -54,6 +54,7 @@ class AndroidRecorderCallback : public AudioRecorderCallback {
       RECORDER_CALLBACK_SPSC_WAIT_STRATEGY>>
       offloader_;
   void taskOffloaderFunction(CallbackData data);
+  std::mutex callbackMutex_;
 };
 
 } // namespace audioapi

--- a/packages/react-native-audio-api/ios/audioapi/ios/core/utils/IOSRecorderCallback.h
+++ b/packages/react-native-audio-api/ios/audioapi/ios/core/utils/IOSRecorderCallback.h
@@ -54,6 +54,7 @@ class IOSRecorderCallback : public AudioRecorderCallback {
       offloader_;
   // delay initialization of offloader until prepare is called
   void taskOffloaderFunction(CallbackData data);
+  std::mutex callbackMutex_;
 };
 
 } // namespace audioapi

--- a/packages/react-native-audio-api/ios/audioapi/ios/core/utils/IOSRecorderCallback.mm
+++ b/packages/react-native-audio-api/ios/audioapi/ios/core/utils/IOSRecorderCallback.mm
@@ -11,6 +11,8 @@
 #include <audioapi/utils/CircularArray.hpp>
 #include <audioapi/utils/Result.hpp>
 #include <algorithm>
+#include <cstdlib>
+#include <cstring>
 #include <utility>
 
 namespace audioapi {
@@ -132,7 +134,45 @@ void IOSRecorderCallback::receiveAudioData(const AudioBufferList *inputBuffer, i
   if (!isInitialized_.load(std::memory_order_acquire)) {
     return;
   }
-  offloader_->getSender()->send({inputBuffer, numFrames});
+
+  // CoreAudio owns `inputBuffer` only for the duration of this synchronous
+  // callback. Copy into an owned AudioBufferList before handing off to the
+  // worker thread; the consumer in taskOffloaderFunction frees it.
+  UInt32 bufferCount = inputBuffer->mNumberBuffers;
+  size_t headerSize = offsetof(AudioBufferList, mBuffers) + sizeof(AudioBuffer) * bufferCount;
+  AudioBufferList *owned = static_cast<AudioBufferList *>(std::malloc(headerSize));
+  if (owned == nullptr) {
+    return;
+  }
+  owned->mNumberBuffers = bufferCount;
+  for (UInt32 i = 0; i < bufferCount; ++i) {
+    UInt32 byteSize = inputBuffer->mBuffers[i].mDataByteSize;
+    owned->mBuffers[i].mNumberChannels = inputBuffer->mBuffers[i].mNumberChannels;
+    owned->mBuffers[i].mDataByteSize = byteSize;
+    void *channelData = std::malloc(byteSize);
+    if (channelData == nullptr) {
+      for (UInt32 j = 0; j < i; ++j) {
+        std::free(owned->mBuffers[j].mData);
+      }
+      std::free(owned);
+      return;
+    }
+    std::memcpy(channelData, inputBuffer->mBuffers[i].mData, byteSize);
+    owned->mBuffers[i].mData = channelData;
+  }
+
+  offloader_->getSender()->send({owned, numFrames});
+}
+
+static inline void freeOwnedAudioBufferList(const AudioBufferList *bufferList)
+{
+  if (bufferList == nullptr) {
+    return;
+  }
+  for (UInt32 i = 0; i < bufferList->mNumberBuffers; ++i) {
+    std::free(bufferList->mBuffers[i].mData);
+  }
+  std::free(const_cast<AudioBufferList *>(bufferList));
 }
 
 void IOSRecorderCallback::taskOffloaderFunction(CallbackData data)
@@ -152,6 +192,7 @@ void IOSRecorderCallback::taskOffloaderFunction(CallbackData data)
         circularBuffer_[i]->push_back(data, numFrames);
       }
 
+      freeOwnedAudioBufferList(inputBuffer);
       inputBuffer = nullptr;
       if (circularBuffer_[0]->getNumberOfAvailableFrames() >= bufferLength_) {
         emitAudioData();
@@ -168,6 +209,7 @@ void IOSRecorderCallback::taskOffloaderFunction(CallbackData data)
           inputBuffer->mBuffers[i].mDataByteSize);
     }
 
+    freeOwnedAudioBufferList(inputBuffer);
     inputBuffer = nullptr;
     converterInputBuffer_.frameLength = numFrames;
 

--- a/packages/react-native-audio-api/ios/audioapi/ios/core/utils/IOSRecorderCallback.mm
+++ b/packages/react-native-audio-api/ios/audioapi/ios/core/utils/IOSRecorderCallback.mm
@@ -96,7 +96,7 @@ Result<NoneType, std::string> IOSRecorderCallback::prepare(
 /// This method should be called from the JS thread only.
 void IOSRecorderCallback::cleanup()
 {
-  std::scoped_lock(callbackMutex_);
+  std::scoped_lock lock(callbackMutex_);
   @autoreleasepool {
     if (circularBuffer_[0]->getNumberOfAvailableFrames() > 0) {
       emitAudioData(true);
@@ -174,7 +174,7 @@ void IOSRecorderCallback::taskOffloaderFunction(CallbackData data)
   // (data == nullptr) to unblock the receiver; ignore it here.
   if (inputBuffer == nullptr)
     return;
-  std::scoped_lock(callbackMutex_);
+  std::scoped_lock lock(callbackMutex_);
   @autoreleasepool {
     NSError *error = nil;
 

--- a/packages/react-native-audio-api/ios/audioapi/ios/core/utils/IOSRecorderCallback.mm
+++ b/packages/react-native-audio-api/ios/audioapi/ios/core/utils/IOSRecorderCallback.mm
@@ -34,17 +34,7 @@ IOSRecorderCallback::IOSRecorderCallback(
 
 IOSRecorderCallback::~IOSRecorderCallback()
 {
-  @autoreleasepool {
-    converter_ = nil;
-    bufferFormat_ = nil;
-    callbackFormat_ = nil;
-    converterInputBuffer_ = nil;
-    converterOutputBuffer_ = nil;
-
-    for (size_t i = 0; i < channelCount_; ++i) {
-      circularBuffer_[i]->zero();
-    }
-  }
+  cleanup();
 }
 
 /// @brief Prepares the IOSRecorderCallback for receiving audio data.
@@ -106,6 +96,7 @@ Result<NoneType, std::string> IOSRecorderCallback::prepare(
 /// This method should be called from the JS thread only.
 void IOSRecorderCallback::cleanup()
 {
+  std::scoped_lock(callbackMutex_);
   @autoreleasepool {
     if (circularBuffer_[0]->getNumberOfAvailableFrames() > 0) {
       emitAudioData(true);
@@ -117,7 +108,7 @@ void IOSRecorderCallback::cleanup()
     converterInputBuffer_ = nil;
     converterOutputBuffer_ = nil;
 
-    for (size_t i = 0; i < channelCount_; ++i) {
+    for (int i = 0; i < channelCount_; ++i) {
       circularBuffer_[i]->zero();
     }
     offloader_.reset();
@@ -178,9 +169,12 @@ static inline void freeOwnedAudioBufferList(const AudioBufferList *bufferList)
 void IOSRecorderCallback::taskOffloaderFunction(CallbackData data)
 {
   auto [inputBuffer, numFrames] = data;
-  // dummy data to wake up thread after cleanup, skip processing it
+
+  // The TaskOffloader destructor sends a default-constructed CallbackData
+  // (data == nullptr) to unblock the receiver; ignore it here.
   if (inputBuffer == nullptr)
     return;
+  std::scoped_lock(callbackMutex_);
   @autoreleasepool {
     NSError *error = nil;
 


### PR DESCRIPTION
Closes #1053

## Introduced changes

`IOSRecorderCallback::receiveAudioData` and `AndroidRecorderCallback::receiveAudioData` were pushing the raw audio buffer pointer received from the platform (CoreAudio render callback on iOS, Oboe data callback on Android) onto an SPSC queue and then dereferencing it asynchronously from the offloader worker thread. Both the iOS `AudioBufferList *` and the Android `void *` are owned by the audio system only for the duration of the synchronous callback — by the time the worker thread runs `memcpy` (iOS) or `ma_data_converter_process_pcm_frames` (Android), the source buffer can already be reused or freed. That's a use-after-free; in production it surfaces as a `_platform_memmove` segfault inside `IOSRecorderCallback::taskOffloaderFunction`.

This PR copies the buffer into an owned allocation in `receiveAudioData` and frees it after the worker is done with it on every code path:

- **iOS** — allocate a new `AudioBufferList` header plus per-channel `mData`, deep-copy the contents, send the owned pointer through the queue, and free it via a small `freeOwnedAudioBufferList` helper after both the fast (matching format) and the converter (resampling) paths have read from it.
- **Android** — `ma_malloc` an owned buffer, `std::memcpy` the frames, and `ma_free` after both the fast and resampling paths in `taskOffloaderFunction`. Also added a guard that ignores the `data == nullptr` sentinel that the `TaskOffloader` destructor sends to unblock the worker, since that sentinel carries no allocation to free.

The fix is symmetric on both platforms; the underlying mistake (capturing a borrowed buffer and reading it across threads) was the same on both sides.

## Reproduction

The race is hard to reproduce deterministically — it depends on the SPSC worker being preempted long enough for the audio system to reuse the source slot before the worker reads it. Inspection alone shows the bug, and the production crash trace in #1053 lands exactly inside the iOS `memcpy` loop at `IOSRecorderCallback.mm:164`.

## Checklist

- [x] Linked relevant issue
- [ ] Updated relevant documentation — n/a, internal correctness fix
- [ ] Added/Conducted relevant tests — the bug is a memory race in native audio thread paths; I'm not aware of an existing harness for these; happy to add one if you can point me at the right place
- [x] Performed self-review of the code
- [ ] Updated Web Audio API coverage — n/a
- [ ] Added support for web — n/a
- [ ] Updated old arch android spec file — n/a