### PR TITLE
fix: bigger event size

### DIFF
--- a/packages/react-native-audio-api/common/cpp/audioapi/utils/CrossThreadEventScheduler.hpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/utils/CrossThreadEventScheduler.hpp
@@ -23,7 +23,7 @@ using namespace channels::spsc;
 /// In this setup no locking happens and modifications can be seen by Audio thread.
 /// @note it is intended to be used for two threads one which schedules events and one which processes them
 /// @note it is not safe to be copied across two threads use std::shared_ptr if you need to share data
-template <typename T, int FunctionSize = 64>
+template <typename T, int FunctionSize = 72>
 class CrossThreadEventScheduler {
   using EventType = FatFunction<FunctionSize, void(T &)>;
 

--- a/packages/react-native-audio-api/common/cpp/audioapi/utils/TaskOffloader.hpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/utils/TaskOffloader.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <audioapi/utils/Macros.h>
 #include <audioapi/utils/SpscChannel.hpp>
 #include <cassert>
 #include <concepts>
@@ -16,7 +17,7 @@ namespace audioapi::task_offloader {
 template <std::default_initializable T, OverflowStrategy Strategy, WaitStrategy Wait>
 class TaskOffloader {
  public:
-  template <typename Func>
+  template <std::invocable<T> Func>
   explicit TaskOffloader(size_t capacity, Func &&task) : shouldRun_(true) {
     auto [sender, receiver] = channels::spsc::channel<T, Strategy, Wait>(capacity);
     sender_ = std::move(sender);
@@ -33,10 +34,7 @@ class TaskOffloader {
   }
 
   // delete other functions
-  TaskOffloader(const TaskOffloader &) = delete;
-  TaskOffloader &operator=(const TaskOffloader &) = delete;
-  TaskOffloader(TaskOffloader &&other) = delete;
-  TaskOffloader &operator=(TaskOffloader &&other) = delete;
+  DELETE_COPY_AND_MOVE(TaskOffloader);
 
   ~TaskOffloader() {
     shouldRun_.store(false, std::memory_order_release);


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## ⚠️ Breaking changes ⚠️

<!-- A brief description of the breaking changes -->

-

## Introduced changes

<!-- A brief description of the changes -->

- currently `AudioBufferQueueSourceNodeHostObject.cpp` has capture group of size 72 B, which exceeds previous max limit (64)

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added/Conducted relevant tests
- [ ] Performed self-review of the code
- [ ] Updated Web Audio API coverage
- [ ] Added support for web
- [ ] Updated old arch android spec file
