### PR TITLE
fix(android): resolve worklets via prefab to avoid missing libworklets.so on fresh builds

### DIFF
--- a/packages/react-native-audio-api/android/src/main/cpp/audioapi/CMakeLists.txt
+++ b/packages/react-native-audio-api/android/src/main/cpp/audioapi/CMakeLists.txt
@@ -102,19 +102,25 @@ if(NOT RN_AUDIO_API_STATIC_EXTERNAL_LIBS_DISABLED)
 endif()
 
 if(RN_AUDIO_API_WORKLETS_ENABLED)
-  # Import the worklets library (similar to how Reanimated does it)
-  add_library(worklets SHARED IMPORTED)
-  set_target_properties(
-    worklets
-    PROPERTIES
-      IMPORTED_LOCATION
-      "${REACT_NATIVE_WORKLETS_DIR}/build/intermediates/cmake/${BUILD_TYPE}/obj/${ANDROID_ABI}/libworklets.so"
-  )
   list(APPEND INCLUDE_LIBRARIES
     "${REACT_NATIVE_WORKLETS_DIR}/../Common/cpp"
     "${REACT_NATIVE_WORKLETS_DIR}/src/main/cpp"
   )
-  list(APPEND LINK_LIBRARIES worklets)
+
+  find_package(react-native-worklets CONFIG QUIET)
+  if(react-native-worklets_FOUND)
+    list(APPEND LINK_LIBRARIES react-native-worklets::worklets)
+  else()
+    # Fallback for environments without prefab publication (older worklets)
+    add_library(worklets SHARED IMPORTED)
+    set_target_properties(
+      worklets
+      PROPERTIES
+        IMPORTED_LOCATION
+        "${REACT_NATIVE_WORKLETS_DIR}/build/intermediates/cmake/${BUILD_TYPE}/obj/${ANDROID_ABI}/libworklets.so"
+    )
+    list(APPEND LINK_LIBRARIES worklets)
+  endif()
 endif()
 
 target_include_directories(


### PR DESCRIPTION
Closes #

## ⚠️ Breaking changes ⚠️

-

## Introduced changes

- Resolve `libworklets.so` via `find_package(react-native-worklets CONFIG)` instead of hardcoding AGP's legacy `intermediates/cmake/<type>/obj/<abi>/libworklets.so` path. AGP 8 populates that path only for *consumed* prefab dependencies, never for a module's own output — cold-cache builds therefore fail with `missing and no known rule to make it`. The legacy path is kept as a fallback when the prefab lookup is unavailable (older worklets versions).
- Mirrors the equivalent fix in expo-modules-core (expo/expo#43863).

## Checklist

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [x] Added/Conducted relevant tests
- [x] Performed self-review of the code
- [ ] Updated Web Audio API coverage
- [ ] Added support for web
- [ ] Updated old arch android spec file