### PR TITLE
fix(PeriodicWave): use < instead of <= for 24 kHz table size boundary

### DIFF
--- a/packages/react-native-audio-api/common/cpp/audioapi/core/effects/PeriodicWave.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/effects/PeriodicWave.cpp
@@ -74,7 +74,7 @@ PeriodicWave::PeriodicWave(
 }
 
 int PeriodicWave::getPeriodicWaveSize() const {
-  if (sampleRate_ <= 24000) {
+  if (sampleRate_ < 24000) {
     return 2048;
   }
 


### PR DESCRIPTION
On Android devices where `PROPERTY_OUTPUT_SAMPLE_RATE` is exactly 24000,
`new AudioContext()` sets `sampleRate_` to 24000 and `getPeriodicWaveSize()`
returned 2048 (Nyquist 12 kHz), causing OscillatorNode to roll off severely
from ~9.5 kHz and be silent at 12 kHz.

Change `<=` to `<` so that exactly-24000 Hz gets the 4096-entry table.
Reading back the actual Oboe stream rate after open is a separate follow-up.

<!-- Reference any GitHub issues resolved by this PR -->

Closes #1080

## ⚠️ Breaking changes ⚠️

None.

## Introduced changes

- `PeriodicWave::getPeriodicWaveSize()`: change `<= 24000` to `< 24000` so devices with a 24 kHz preferred sample rate use the 4096-entry wavetable instead of 2048

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added/Conducted relevant tests
- [x] Performed self-review of the code
- [ ] Updated Web Audio API coverage
- [ ] Added support for web
- [ ] Updated old arch android spec file
