### PR TITLE
fix: fall back to non-pmr BoundedPriorityQueue on runtimes without std::pmr

### DIFF
--- a/packages/react-native-audio-api/common/cpp/audioapi/utils/BoundedPriorityQueue.hpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/utils/BoundedPriorityQueue.hpp
@@ -4,11 +4,132 @@
 #include <array>
 #include <cstddef>
 #include <functional>
-#include <memory_resource>
 #include <set>
 #include <utility>
 
+// --- std::pmr availability gate ---------------------------------------------
+// std::pmr's runtime symbols ship in Apple's system libc++ only from
+// iOS 17.0 / macOS 14.0 / tvOS 17.0 / watchOS 10.0 onward
+// (_LIBCPP_AVAILABILITY_HAS_PMR maps to _LIBCPP_INTRODUCED_IN_LLVM_16).
+// libc++ currently leaves the pmr availability *markup* empty
+// (see llvm/llvm-project#40340), so using std::pmr below those versions
+// compiles without any diagnostic but fails at dyld load time:
+//   Symbol not found: std::__1::pmr::memory_resource::~memory_resource()
+// On those targets we fall back to a std::multiset backed by an in-object,
+// non-pmr pool allocator that preserves the original design intent: a fixed
+// buffer, node recycling, and no heap allocation (audio-thread / real-time
+// safe). Define AUDIOAPI_HAS_PMR before including this header to override.
+#if !defined(AUDIOAPI_HAS_PMR)
+#  if defined(_LIBCPP_VERSION) && defined(_LIBCPP_AVAILABILITY_HAS_PMR) && \
+      !_LIBCPP_AVAILABILITY_HAS_PMR
+#    define AUDIOAPI_HAS_PMR 0
+#  else
+#    define AUDIOAPI_HAS_PMR 1
+#  endif
+#endif
+
+#if AUDIOAPI_HAS_PMR
+#  include <memory_resource>
+#else
+#  include <new>
+#endif
+
 namespace audioapi {
+
+#if !AUDIOAPI_HAS_PMR
+namespace bpq_detail {
+
+/// @brief Fixed-capacity, in-object block pool with an intrusive free list.
+/// Hands out fixed-size slots and recycles freed ones; never touches the heap.
+/// Throws std::bad_alloc on exhaustion, matching the std::pmr path's
+/// null_memory_resource upstream behaviour.
+template <std::size_t Capacity, std::size_t BlockSize, std::size_t Align>
+class FixedBlockPool {
+ public:
+  FixedBlockPool() = default;
+  FixedBlockPool(const FixedBlockPool &) = delete;
+  FixedBlockPool &operator=(const FixedBlockPool &) = delete;
+
+  void *allocate(std::size_t bytes) {
+    // The multiset allocates tree nodes one at a time, all the same size.
+    if (bytes > kSlotSize) [[unlikely]] {
+      throw std::bad_alloc();
+    }
+    if (freeList_ != nullptr) {
+      void *block = freeList_;
+      freeList_ = nextOf(block);
+      return block;
+    }
+    if (used_ >= Capacity) [[unlikely]] {
+      throw std::bad_alloc();
+    }
+    return &storage_[used_++ * kSlotSize];
+  }
+
+  void deallocate(void *block) noexcept {
+    nextOf(block) = freeList_;
+    freeList_ = block;
+  }
+
+ private:
+  // Round the requested block size up to the pool alignment. A slot is always
+  // >= sizeof(void*), so the free list is stored intrusively in freed slots.
+  static constexpr std::size_t kSlotSize =
+      ((BlockSize + Align - 1) / Align) * Align;
+
+  static void *&nextOf(void *block) noexcept {
+    return *static_cast<void **>(block);
+  }
+
+  alignas(Align) std::array<std::byte, Capacity * kSlotSize> storage_{};
+  void *freeList_ = nullptr;
+  std::size_t used_ = 0;
+};
+
+/// @brief Stateful allocator that draws node storage from a FixedBlockPool.
+/// Satisfies the C++ Allocator requirements used by std::multiset.
+template <typename T, typename Pool>
+class PoolAllocator {
+ public:
+  using value_type = T;
+
+  template <typename U>
+  struct rebind {
+    using other = PoolAllocator<U, Pool>;
+  };
+
+  explicit PoolAllocator(Pool *pool) noexcept : pool_(pool) {}
+
+  template <typename U>
+  PoolAllocator(const PoolAllocator<U, Pool> &other) noexcept // NOLINT(runtime/explicit)
+      : pool_(other.pool_) {}
+
+  T *allocate(std::size_t n) {
+    return static_cast<T *>(pool_->allocate(n * sizeof(T)));
+  }
+
+  void deallocate(T *p, std::size_t /*n*/) noexcept {
+    pool_->deallocate(p);
+  }
+
+  template <typename U>
+  bool operator==(const PoolAllocator<U, Pool> &o) const noexcept {
+    return pool_ == o.pool_;
+  }
+  template <typename U>
+  bool operator!=(const PoolAllocator<U, Pool> &o) const noexcept {
+    return pool_ != o.pool_;
+  }
+
+ private:
+  template <typename, typename>
+  friend class PoolAllocator;
+
+  Pool *pool_;
+};
+
+} // namespace bpq_detail
+#endif // !AUDIOAPI_HAS_PMR
 
 /// @brief A bounded priority queue with fixed capacity backed by a static pool allocator.
 /// Elements are kept in ascending sorted order (smallest element at front).
@@ -22,6 +143,7 @@ namespace audioapi {
 template <typename T, size_t Capacity, typename Compare = std::less<T>>
 class BoundedPriorityQueue {
  private:
+#if AUDIOAPI_HAS_PMR
   using SetType = std::pmr::multiset<T, Compare>;
 
   static constexpr size_t kNodeOverhead = 96;
@@ -39,6 +161,22 @@ class BoundedPriorityQueue {
       std::pmr::pool_options{.max_blocks_per_chunk = 1, .largest_required_pool_block = 0},
       &mono_};
   SetType set_{Compare{}, &pool_};
+#else
+  static constexpr size_t kNodeOverhead = 96;
+  // Upper bound on a std::multiset red-black-tree node holding a T (value plus
+  // tree links/color). Generous headroom, matching the std::pmr path above.
+  static constexpr size_t kBlockSize = sizeof(T) + kNodeOverhead;
+
+  using PoolType =
+      bpq_detail::FixedBlockPool<Capacity, kBlockSize, alignof(std::max_align_t)>;
+  using AllocType = bpq_detail::PoolAllocator<T, PoolType>;
+  using SetType = std::multiset<T, Compare, AllocType>;
+
+  // Members must be declared in this order: pool_ → set_.
+  // set_ allocates its nodes from pool_, so pool_ must outlive it.
+  PoolType pool_;
+  SetType set_{Compare{}, AllocType{&pool_}};
+#endif
 
  public:
   explicit BoundedPriorityQueue() = default;

--- a/packages/react-native-audio-api/common/cpp/audioapi/utils/BoundedPriorityQueue.hpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/utils/BoundedPriorityQueue.hpp
@@ -20,24 +20,24 @@
 // buffer, node recycling, and no heap allocation (audio-thread / real-time
 // safe). Define AUDIOAPI_HAS_PMR before including this header to override.
 #if !defined(AUDIOAPI_HAS_PMR)
-#  if defined(_LIBCPP_VERSION) && defined(_LIBCPP_AVAILABILITY_HAS_PMR) && \
-      !_LIBCPP_AVAILABILITY_HAS_PMR
-#    define AUDIOAPI_HAS_PMR 0
-#  else
-#    define AUDIOAPI_HAS_PMR 1
-#  endif
+#if defined(_LIBCPP_VERSION) && defined(_LIBCPP_AVAILABILITY_HAS_PMR) && \
+    !_LIBCPP_AVAILABILITY_HAS_PMR
+#define AUDIOAPI_HAS_PMR 0
+#else
+#define AUDIOAPI_HAS_PMR 1
+#endif
 #endif
 
 #if AUDIOAPI_HAS_PMR
-#  include <memory_resource>
+#include <memory_resource>
 #else
-#  include <new>
+#include <new>
 #endif
 
 namespace audioapi {
 
 #if !AUDIOAPI_HAS_PMR
-namespace bpq_detail {
+namespace no_pmr {
 
 /// @brief Fixed-capacity, in-object block pool with an intrusive free list.
 /// Hands out fixed-size slots and recycles freed ones; never touches the heap.
@@ -46,10 +46,6 @@ namespace bpq_detail {
 template <std::size_t Capacity, std::size_t BlockSize, std::size_t Align>
 class FixedBlockPool {
  public:
-  FixedBlockPool() = default;
-  FixedBlockPool(const FixedBlockPool &) = delete;
-  FixedBlockPool &operator=(const FixedBlockPool &) = delete;
-
   void *allocate(std::size_t bytes) {
     // The multiset allocates tree nodes one at a time, all the same size.
     if (bytes > kSlotSize) [[unlikely]] {
@@ -74,8 +70,7 @@ class FixedBlockPool {
  private:
   // Round the requested block size up to the pool alignment. A slot is always
   // >= sizeof(void*), so the free list is stored intrusively in freed slots.
-  static constexpr std::size_t kSlotSize =
-      ((BlockSize + Align - 1) / Align) * Align;
+  static constexpr std::size_t kSlotSize = ((BlockSize + Align - 1) / Align) * Align;
 
   static void *&nextOf(void *block) noexcept {
     return *static_cast<void **>(block);
@@ -102,7 +97,7 @@ class PoolAllocator {
 
   template <typename U>
   PoolAllocator(const PoolAllocator<U, Pool> &other) noexcept // NOLINT(runtime/explicit)
-      : pool_(other.pool_) {}
+      : pool_(other.pool()) {}
 
   T *allocate(std::size_t n) {
     return static_cast<T *>(pool_->allocate(n * sizeof(T)));
@@ -112,23 +107,24 @@ class PoolAllocator {
     pool_->deallocate(p);
   }
 
+  [[nodiscard]] Pool *pool() const noexcept {
+    return pool_;
+  }
+
   template <typename U>
   bool operator==(const PoolAllocator<U, Pool> &o) const noexcept {
-    return pool_ == o.pool_;
+    return pool_ == o.pool();
   }
   template <typename U>
   bool operator!=(const PoolAllocator<U, Pool> &o) const noexcept {
-    return pool_ != o.pool_;
+    return pool_ != o.pool();
   }
 
  private:
-  template <typename, typename>
-  friend class PoolAllocator;
-
   Pool *pool_;
 };
 
-} // namespace bpq_detail
+} // namespace no_pmr
 #endif // !AUDIOAPI_HAS_PMR
 
 /// @brief A bounded priority queue with fixed capacity backed by a static pool allocator.
@@ -167,9 +163,8 @@ class BoundedPriorityQueue {
   // tree links/color). Generous headroom, matching the std::pmr path above.
   static constexpr size_t kBlockSize = sizeof(T) + kNodeOverhead;
 
-  using PoolType =
-      bpq_detail::FixedBlockPool<Capacity, kBlockSize, alignof(std::max_align_t)>;
-  using AllocType = bpq_detail::PoolAllocator<T, PoolType>;
+  using PoolType = no_pmr::FixedBlockPool<Capacity, kBlockSize, alignof(std::max_align_t)>;
+  using AllocType = no_pmr::PoolAllocator<T, PoolType>;
   using SetType = std::multiset<T, Compare, AllocType>;
 
   // Members must be declared in this order: pool_ → set_.

--- a/packages/react-native-audio-api/common/cpp/test/src/utils/BoundedPriorityQueueTest.cpp
+++ b/packages/react-native-audio-api/common/cpp/test/src/utils/BoundedPriorityQueueTest.cpp
@@ -1,0 +1,114 @@
+// Exercises the non-pmr fallback path of BoundedPriorityQueue (the std::multiset
+// + FixedBlockPool implementation used on runtimes whose libc++ has no std::pmr,
+// e.g. iOS < 17). AUDIOAPI_HAS_PMR is forced to 0 so this path is covered even on
+// hosts whose libc++ does have pmr; the default (std::pmr) path is exercised by
+// the rest of the suite, which compiles the library with the auto-detected gate.
+#define AUDIOAPI_HAS_PMR 0
+
+#include <audioapi/utils/BoundedPriorityQueue.hpp>
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <utility>
+#include <vector>
+
+using namespace audioapi;
+
+namespace {
+
+struct Event {
+  int64_t time;
+  int id;
+};
+
+// Transparent comparator (heterogeneous key lookups), mirroring how the audio
+// param queues use lowerBound/upperBound with a raw time key.
+struct ByTime {
+  using is_transparent = void;
+  bool operator()(const Event &a, const Event &b) const { return a.time < b.time; }
+  bool operator()(const Event &a, int64_t b) const { return a.time < b; }
+  bool operator()(int64_t a, const Event &b) const { return a < b.time; }
+};
+
+} // namespace
+
+TEST(BoundedPriorityQueueTest, KeepsAscendingOrderAndRespectsBounds) {
+  BoundedPriorityQueue<Event, 8, ByTime> q;
+  EXPECT_TRUE(q.isEmpty());
+
+  // Insert with descending keys; the queue must keep them ascending.
+  for (int i = 0; i < 8; ++i) {
+    EXPECT_TRUE(q.push(Event{static_cast<int64_t>(100 - i * 10), i}));
+  }
+  EXPECT_TRUE(q.isFull());
+  EXPECT_EQ(q.size(), 8u);
+  EXPECT_FALSE(q.push(Event{5, 99})); // rejected when full
+  EXPECT_EQ(q.size(), 8u);
+
+  EXPECT_EQ(q.peekFront().time, 30); // 100 - 7*10
+  EXPECT_EQ(q.peekBack().time, 100);
+
+  int64_t prev = -1;
+  for (auto it = q.begin(); it != q.end(); ++it) {
+    EXPECT_LT(prev, it->time);
+    prev = it->time;
+  }
+}
+
+TEST(BoundedPriorityQueueTest, PopReturnsSmallestFirst) {
+  BoundedPriorityQueue<Event, 4, ByTime> q;
+  q.push(Event{30, 0});
+  q.push(Event{10, 1});
+  q.push(Event{20, 2});
+
+  Event out{};
+  EXPECT_TRUE(q.pop(out));
+  EXPECT_EQ(out.time, 10);
+  EXPECT_TRUE(q.pop(out));
+  EXPECT_EQ(out.time, 20);
+  EXPECT_TRUE(q.pop()); // drop 30 without retrieving
+  EXPECT_TRUE(q.isEmpty());
+  EXPECT_FALSE(q.pop(out)); // empty
+}
+
+TEST(BoundedPriorityQueueTest, RecyclesNodesUnderChurn) {
+  // Far more insert/erase cycles than Capacity. If freed nodes were not
+  // recycled the fixed pool would exhaust and allocate() would throw.
+  BoundedPriorityQueue<Event, 8, ByTime> q;
+  for (int i = 0; i < 6; ++i) {
+    q.push(Event{static_cast<int64_t>(i), i});
+  }
+  int64_t key = 1000;
+  for (int round = 0; round < 100000; ++round) {
+    ASSERT_TRUE(q.push(Event{key++, round}));
+    ASSERT_TRUE(q.pop());
+  }
+  EXPECT_EQ(q.size(), 6u);
+}
+
+TEST(BoundedPriorityQueueTest, BoundsExtractMutateAndReinsert) {
+  BoundedPriorityQueue<Event, 8, ByTime> q;
+  for (int i = 0; i < 5; ++i) {
+    q.push(Event{static_cast<int64_t>(i * 10), i}); // 0,10,20,30,40
+  }
+
+  auto it = q.upperBound(static_cast<int64_t>(15)); // first key > 15 -> 20
+  ASSERT_NE(it, q.end());
+  EXPECT_EQ(it->time, 20);
+
+  auto node = q.extract(it);     // detach node holding 20
+  node.value().time = 25;        // mutate key while detached (no reallocation)
+  q.insert(q.upperBound(static_cast<int64_t>(25)), std::move(node));
+  EXPECT_EQ(q.size(), 5u);
+
+  std::vector<int64_t> times;
+  for (auto i = q.begin(); i != q.end(); ++i) {
+    times.push_back(i->time);
+  }
+  EXPECT_EQ(times, (std::vector<int64_t>{0, 10, 25, 30, 40}));
+
+  // Range erase: drop everything >= 30.
+  q.erase(q.lowerBound(static_cast<int64_t>(30)), q.end());
+  EXPECT_EQ(q.size(), 3u);
+  EXPECT_EQ(q.peekBack().time, 25);
+}

--- a/packages/react-native-audio-api/common/cpp/test/src/utils/BoundedPriorityQueueTest.cpp
+++ b/packages/react-native-audio-api/common/cpp/test/src/utils/BoundedPriorityQueueTest.cpp
@@ -25,9 +25,15 @@ struct Event {
 // param queues use lowerBound/upperBound with a raw time key.
 struct ByTime {
   using is_transparent = void;
-  bool operator()(const Event &a, const Event &b) const { return a.time < b.time; }
-  bool operator()(const Event &a, int64_t b) const { return a.time < b; }
-  bool operator()(int64_t a, const Event &b) const { return a < b.time; }
+  bool operator()(const Event &a, const Event &b) const {
+    return a.time < b.time;
+  }
+  bool operator()(const Event &a, int64_t b) const {
+    return a.time < b;
+  }
+  bool operator()(int64_t a, const Event &b) const {
+    return a < b.time;
+  }
 };
 
 } // namespace
@@ -96,8 +102,8 @@ TEST(BoundedPriorityQueueTest, BoundsExtractMutateAndReinsert) {
   ASSERT_NE(it, q.end());
   EXPECT_EQ(it->time, 20);
 
-  auto node = q.extract(it);     // detach node holding 20
-  node.value().time = 25;        // mutate key while detached (no reallocation)
+  auto node = q.extract(it); // detach node holding 20
+  node.value().time = 25;    // mutate key while detached (no reallocation)
   q.insert(q.upperBound(static_cast<int64_t>(25)), std::move(node));
   EXPECT_EQ(q.size(), 5u);
 


### PR DESCRIPTION
## Summary

`BoundedPriorityQueue` is backed by `std::pmr` (`multiset` + `monotonic_buffer_resource` + `unsynchronized_pool_resource`). On Apple platforms those runtime symbols only exist in the system `libc++` from **iOS 17.0 / macOS 14.0 / tvOS 17.0 / watchOS 10.0** (`_LIBCPP_AVAILABILITY_HAS_PMR` → `_LIBCPP_INTRODUCED_IN_LLVM_16`).

libc++ currently leaves the pmr availability **markup empty** (see the `// TODO: Enable std::pmr markup once llvm/llvm-project#40340 ...` note in `<__configuration/availability.h>`), so using `std::pmr` below those versions **compiles without any diagnostic** but aborts at **dyld load time**:

```
Symbol not found: std::__1::pmr::memory_resource::~memory_resource()
```

That crashes every app at launch on iOS < 17 — see #1071 (also confirmed there on production App Store builds and real devices).

## Approach

Following @mdydek's preference in #1071 (keep `std::pmr`, add an STL fallback for older runtimes):

- Gate the `std::pmr` implementation behind a new `AUDIOAPI_HAS_PMR` macro, **auto-detected from libc++'s own `_LIBCPP_AVAILABILITY_HAS_PMR`** so it tracks each platform's threshold automatically (Android keeps pmr). It can be overridden by defining `AUDIOAPI_HAS_PMR` before including the header.
- When pmr is unavailable, back the **same `std::multiset`** with an in-object, non-pmr pool allocator (`FixedBlockPool` + `PoolAllocator`) that preserves the original design intent: a fixed buffer, node recycling via an intrusive free list, and **no heap allocation** — so the audio-thread / real-time behavior is kept on the fallback too, not regressed to a heap-backed `std::multiset`.

The container type and the entire public API are unchanged, so **iOS 17+ / Android keep the existing `std::pmr` fast path untouched** — only sub‑iOS‑17 (and equivalent) builds compile the fallback.

## Tests

Adds `common/cpp/test/src/utils/BoundedPriorityQueueTest.cpp`. It `#define`s `AUDIOAPI_HAS_PMR 0` so the **fallback path is exercised even on CI hosts whose libc++ has pmr** (the default path is already compiled into the rest of the suite). Covers:

- ascending order + capacity bounds (full → rejected),
- `pop` returns the smallest element first,
- **node recycling under 100k insert/erase cycles** (proves the free list reclaims; no pool exhaustion),
- heterogeneous `lowerBound` / `upperBound` (transparent comparator),
- `extract` → mutate key → reinsert with hint, and range `erase`.

Verified locally: builds clean for `arm64-apple-ios15.1` with **zero `pmr` symbols** in the resulting object (`nm`), the default (pmr) branch still compiles on a pmr-capable host, and all 4 gtest cases pass. (ASan/UBSan/TSan variants left to CI — the local macOS 26 ASan runtime hangs at startup even for a trivial program.)

## Notes

- No podspec change needed — the `ios_min_version = '14.0'` claim becomes correct again with the fallback in place.
- Happy to adjust the macro name/placement, or split the fallback allocator into its own header, if you'd prefer.

Fixes #1071
