### PR TITLE
fix(android): stop resurrecting stopped recorders on stream disconnect

### DIFF
--- a/packages/react-native-audio-api/android/src/main/cpp/audioapi/android/core/AndroidAudioRecorder.cpp
+++ b/packages/react-native-audio-api/android/src/main/cpp/audioapi/android/core/AndroidAudioRecorder.cpp
@@ -182,13 +182,19 @@ AndroidAudioRecorder::stop() {
           "Recorder is not in recording state.");
     }
 
-    if (mStream_ == nullptr) {
-      return Result<std::tuple<std::vector<std::string>, double, double>, std::string>::Err(
-          "Audio stream is not initialized.");
-    }
-
     state_.store(RecorderState::Idle, std::memory_order_release);
-    mStream_->requestStop();
+
+    // Fully close the stream rather than just stopping it. A stopped-but-open
+    // stream keeps the data/error callbacks registered, so a later device
+    // disconnect fires onErrorAfterClose and resurrects the stream (the mic
+    // stays hot after stop()), and the stream's shared_ptr to this recorder
+    // keeps the recorder alive forever once JS drops it (reference cycle).
+    // start() reopens the stream when mStream_ is null.
+    if (mStream_ != nullptr) {
+      mStream_->requestStop();
+      mStream_->close();
+      mStream_.reset();
+    }
 
     hadFileOutput = usesFileOutput();
 
@@ -358,6 +364,8 @@ void AndroidAudioRecorder::disableFileOutput() {
 /// For session without active file output, this method acts same as stop().
 /// This method should be called from the JS thread only.
 void AndroidAudioRecorder::pause() {
+  std::scoped_lock pauseLock(callbackMutex_, fileWriterMutex_, adapterNodeMutex_);
+
   if (!isRecording()) {
     return;
   }
@@ -369,7 +377,9 @@ void AndroidAudioRecorder::pause() {
 /// @brief Resumes the audio recording stream if it was previously paused.
 /// This method should be called from the JS thread only.
 void AndroidAudioRecorder::resume() {
-  if (!isPaused()) {
+  std::scoped_lock resumeLock(callbackMutex_, fileWriterMutex_, adapterNodeMutex_);
+
+  if (!isPaused() || mStream_ == nullptr) {
     return;
   }
 
@@ -511,7 +521,7 @@ oboe::DataCallbackResult AndroidAudioRecorder::onAudioReady(
 
 bool AndroidAudioRecorder::isRecording() const {
   return state_.load(std::memory_order_acquire) == RecorderState::Recording &&
-      mStream_->getState() == oboe::StreamState::Started;
+      mStream_ != nullptr && mStream_->getState() == oboe::StreamState::Started;
 }
 
 bool AndroidAudioRecorder::isPaused() const {
@@ -537,29 +547,50 @@ void AndroidAudioRecorder::cleanup() {
 /// @param oboeStream Pointer to the Oboe audio stream.
 /// @param error The oboe::Result error code.
 void AndroidAudioRecorder::onErrorAfterClose(oboe::AudioStream *stream, oboe::Result error) {
-  if (error == oboe::Result::ErrorDisconnected) {
-    cleanup();
+  if (error != oboe::Result::ErrorDisconnected) {
+    return;
+  }
 
-    auto streamResult = openAudioStream();
+  // Serialize with start()/stop(): they mutate mStream_ under these locks on
+  // the JS thread while this runs on oboe's (detached) error thread.
+  std::scoped_lock restartLock(callbackMutex_, fileWriterMutex_, adapterNodeMutex_);
 
-    if (!streamResult.is_ok()) {
-      uint64_t callbackId = errorCallbackId_.load(std::memory_order_acquire);
+  // Only restart if the recorder is still supposed to be running. Restarting
+  // unconditionally resurrected stopped recorders, so any audio route change
+  // (e.g. a Bluetooth headset connecting or disconnecting) turned the mic
+  // back on after stop().
+  if (isIdle()) {
+    return;
+  }
 
-      if (audioEventHandlerRegistry_ == nullptr || callbackId == 0) {
-        return;
-      }
+  // The error thread is detached and can arrive late: if stop()/start() have
+  // already replaced the stream this error belongs to, don't tear down the
+  // healthy new stream.
+  if (stream != mStream_.get()) {
+    return;
+  }
 
-      std::string message = "Android recorder error: " + streamResult.unwrap_err();
-      audioEventHandlerRegistry_->dispatchEvent(
-          AudioEvent::RECORDER_ERROR,
-          callbackId,
-          StringPayload{.name = "message", .reason = std::move(message)});
+  cleanup();
+
+  auto streamResult = openAudioStream();
+
+  if (!streamResult.is_ok()) {
+    uint64_t callbackId = errorCallbackId_.load(std::memory_order_acquire);
+
+    if (audioEventHandlerRegistry_ == nullptr || callbackId == 0) {
       return;
     }
 
-    mStream_->requestStart();
-    state_.store(RecorderState::Recording, std::memory_order_release);
+    std::string message = "Android recorder error: " + streamResult.unwrap_err();
+    audioEventHandlerRegistry_->dispatchEvent(
+        AudioEvent::RECORDER_ERROR,
+        callbackId,
+        StringPayload{.name = "message", .reason = std::move(message)});
+    return;
   }
+
+  mStream_->requestStart();
+  state_.store(RecorderState::Recording, std::memory_order_release);
 }
 
 } // namespace audioapi

--- a/packages/react-native-audio-api/android/src/main/cpp/audioapi/android/core/AndroidAudioRecorder.cpp
+++ b/packages/react-native-audio-api/android/src/main/cpp/audioapi/android/core/AndroidAudioRecorder.cpp
@@ -548,20 +548,26 @@ void AndroidAudioRecorder::cleanup() {
 /// @param error The oboe::Result error code.
 void AndroidAudioRecorder::onErrorAfterClose(oboe::AudioStream *stream, oboe::Result error) {
   if (error != oboe::Result::ErrorDisconnected) {
+    std::string message = "Android recorder error: " + std::string(oboe::convertToText(error));
+    auto callbackId = errorCallbackId_.load(std::memory_order_acquire);
+    audioEventHandlerRegistry_->dispatchEvent(
+        AudioEvent::RECORDER_ERROR,
+        callbackId,
+        StringPayload{.name = "message", .reason = std::move(message)});
+    return;
+  }
+
+  // Only restart if the recorder is still supposed to be running. Restarting
+  // unconditionally resurrected stopped recorders, so any audio route change
+  // (e.g. a Bluetooth headset connecting or disconnecting) turned the mic
+  // back on after stop().
+  if (isIdle() || isPaused()) {
     return;
   }
 
   // Serialize with start()/stop(): they mutate mStream_ under these locks on
   // the JS thread while this runs on oboe's (detached) error thread.
   std::scoped_lock restartLock(callbackMutex_, fileWriterMutex_, adapterNodeMutex_);
-
-  // Only restart if the recorder is still supposed to be running. Restarting
-  // unconditionally resurrected stopped recorders, so any audio route change
-  // (e.g. a Bluetooth headset connecting or disconnecting) turned the mic
-  // back on after stop().
-  if (isIdle()) {
-    return;
-  }
 
   // The error thread is detached and can arrive late: if stop()/start() have
   // already replaced the stream this error belongs to, don't tear down the


### PR DESCRIPTION
Fixes #1088

## Problem

On Android, a stopped `AudioRecorder` keeps its oboe input stream open (`stop()` only calls `requestStop()`), and `onErrorAfterClose()` unconditionally reopens and restarts the stream on `ErrorDisconnected`. Any audio route change — e.g. a Bluetooth headset connecting or disconnecting — therefore turns the microphone back on after `stop()`. Since the stream holds a `shared_ptr` to the recorder (`shared_from_this()`), the resurrected stream also keeps the recorder alive forever once JS drops it (reference cycle).

`onErrorAfterClose` additionally runs on oboe's *detached* error thread and mutates `mStream_` (via `cleanup()`/`openAudioStream()`) with no synchronization against `start()`/`stop()` on the JS thread. On 0.12.x, where the callbacks were raw pointers, this race produced a production SIGSEGV in `oboe::AudioStream::fireDataCallback` (full tombstone in #1088): the destructor lost the race, the error thread reopened a stream pointing at the freed recorder, and the next mic buffer crashed.

## Changes

- **`stop()`** fully closes and resets the stream, so a stopped recorder has no open stream — no callbacks can fire, no error-restart can resurrect it, and the recorder→stream→recorder reference cycle is broken. `start()` already reopens the stream on demand when `mStream_` is null.
- **`onErrorAfterClose()`**:
  - takes the same `callbackMutex_`/`fileWriterMutex_`/`adapterNodeMutex_` locks as `start()`/`stop()`, serializing all `mStream_` mutation;
  - bails out when the recorder is idle, so stopped recorders stay stopped;
  - bails out when the erroring stream is no longer `mStream_` — the detached error thread can arrive late, after `stop()`/`start()` already replaced the stream, and previously would tear down the healthy new stream (without re-running `prepare()`).
- **`isRecording()`** null-checks `mStream_`, which the error thread can reset concurrently; **`pause()`/`resume()`** take the recorder locks for the same reason (`resume()` also null-checks before `mStream_->start(0)`).

## Deadlock safety

Closing the stream while holding the recorder mutexes is safe:
- `onAudioReady` only ever uses `Locker::tryLock` on these mutexes, so the data callback never blocks on them and `close()`'s wait for in-flight callbacks is bounded.
- oboe error-callback threads are detached (`AudioStreamAAudio::internalErrorCallback`, oboe 1.9.3), so `close()` never joins a thread that might be blocked on these locks; a blocked error thread simply proceeds afterwards and bails on the idle/stale-stream checks.

## Testing

- Compiled for arm64-v8a and running in production as a patch-package patch on 0.12.2 (the same fix plus destructor locking, which `main` no longer needs thanks to `shared_from_this()`).
- Stopped-recorder + Bluetooth route-change no longer restarts the mic; repeated route changes during active recording recover as before via the (now guarded) reopen path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)