### PR TITLE
test: assert PeriodicWave outputs audio at low/high frequencies (#1080)

### DIFF
--- a/packages/react-native-audio-api/common/cpp/test/src/core/sources/OscillatorTest.cpp
+++ b/packages/react-native-audio-api/common/cpp/test/src/core/sources/OscillatorTest.cpp
@@ -1,9 +1,11 @@
 #include <audioapi/core/OfflineAudioContext.h>
+#include <audioapi/core/effects/PeriodicWave.h>
 #include <audioapi/core/sources/OscillatorNode.h>
 #include <audioapi/core/utils/worklets/SafeIncludes.h>
 #include <audioapi/types/NodeOptions.h>
 #include <gtest/gtest.h>
 #include <test/src/MockAudioEventHandlerRegistry.h>
+#include <cmath>
 #include <memory>
 
 using namespace audioapi;
@@ -26,6 +28,22 @@ class OscillatorTest : public ::testing::Test {
 TEST_F(OscillatorTest, OscillatorCanBeCreated) {
   auto osc = context->createOscillator(OscillatorOptions());
   ASSERT_NE(osc, nullptr);
+}
+
+// Regression tests for #1080 off-by-one in createBandLimitedTables silences high frequencies
+
+TEST(PeriodicWaveBandLimiting, SineWaveAtLowFrequencyProducesAudio) {
+  PeriodicWave wave(24000.0f, OscillatorType::SINE, false);
+  const float phase = static_cast<float>(wave.getPeriodicWaveSize()) / 4.0f;
+  float sample = wave.getSample(440.0f, phase, 440.0f * wave.getScale());
+  EXPECT_GT(std::abs(sample), 0.5f);
+}
+
+TEST(PeriodicWaveBandLimiting, SineWaveAtHighFrequencyProducesAudio) {
+  PeriodicWave wave(24000.0f, OscillatorType::SINE, false);
+  const float phase = static_cast<float>(wave.getPeriodicWaveSize()) / 4.0f;
+  float sample = wave.getSample(10000.0f, phase, 10000.0f * wave.getScale());
+  EXPECT_GT(std::abs(sample), 0.1f);
 }
 
 // NOLINTEND


### PR DESCRIPTION
Relates to #1080

## ⚠️ Breaking changes ⚠️

None.

## Introduced changes

- Two `PeriodicWave` band-limiting regression tests in `OscillatorTest.cpp`
- `SineWaveAtLowFrequencyProducesAudio` — 440 Hz at 24 kHz, passes on all versions
- `SineWaveAtHighFrequencyProducesAudio` — 10 kHz at 24 kHz, fails on `main` (sample == 0) and passes after the fix in PR #1083

## Checklist

- [x] Linked relevant issue
- [ ] Updated relevant documentation
- [x] Added/Conducted relevant tests
- [x] Performed self-review of the code
- [ ] Updated Web Audio API coverage
- [ ] Added support for web
- [ ] Updated old arch android spec file
