### PR TITLE
fix(ios): push the frames AVAudioConverter actually produced in the recorder callback

### DIFF
--- a/packages/react-native-audio-api/android/src/main/cpp/audioapi/android/core/utils/AndroidRotatingFileWriter.cpp
+++ b/packages/react-native-audio-api/android/src/main/cpp/audioapi/android/core/utils/AndroidRotatingFileWriter.cpp
@@ -55,12 +55,14 @@ void AndroidRotatingFileWriter::writeAudioData(AudioDataType data, int numFrames
       rotateFiles();
     }
   }
-  framesWritten_.fetch_add(numFrames, std::memory_order_relaxed);
 }
 
 double AndroidRotatingFileWriter::getCurrentDuration() const {
-  return static_cast<double>(framesWritten_.load(std::memory_order_relaxed)) /
-      fileProperties_->sampleRate;
+  double currentSegmentDuration = 0.0;
+  if (currentWriter_ != nullptr) {
+    currentSegmentDuration = currentWriter_->getCurrentDuration();
+  }
+  return cumulativeDurationSec_ + currentSegmentDuration;
 }
 
 void AndroidRotatingFileWriter::rotateFiles() {

--- a/packages/react-native-audio-api/ios/audioapi/ios/core/utils/IOSFileWriter.h
+++ b/packages/react-native-audio-api/ios/audioapi/ios/core/utils/IOSFileWriter.h
@@ -18,6 +18,7 @@ typedef struct objc_object AVAudioConverter;
 #endif // __OBJC__
 
 struct WriterData {
+  // Owned by the worker thread; freed in IOSFileWriter::taskOffloaderFunction.
   const AudioBufferList *audioBufferList;
   int numFrames;
 };

--- a/packages/react-native-audio-api/ios/audioapi/ios/core/utils/IOSFileWriter.mm
+++ b/packages/react-native-audio-api/ios/audioapi/ios/core/utils/IOSFileWriter.mm
@@ -4,11 +4,15 @@
 #include <audioapi/events/AudioEventHandlerRegistry.h>
 #include <audioapi/ios/core/utils/FileOptions.h>
 #include <audioapi/ios/core/utils/IOSFileWriter.h>
+#include <audioapi/ios/core/utils/OwnedAudioBufferList.h>
 #include <audioapi/utils/AudioFileProperties.h>
 #include <audioapi/utils/Result.hpp>
 #include <audioapi/utils/UnitConversion.h>
 
 namespace audioapi {
+
+using ios::copyAudioBufferList;
+using ios::freeOwnedAudioBufferList;
 
 IOSFileWriter::IOSFileWriter(
     const std::shared_ptr<AudioEventHandlerRegistry> &audioEventHandlerRegistry,
@@ -157,34 +161,45 @@ void IOSFileWriter::writeAudioData(const AudioBufferList *audioBufferList, int n
 {
   if (audioFile_ == nil) {
     invokeOnErrorCallback("Attempted to write audio data when file is not open");
-  } else {
-    offloader_->getSender()->send({audioBufferList, numFrames});
+    return;
   }
+
+  // CoreAudio owns `audioBufferList` only for the duration of this synchronous
+  // callback. Copy into an owned AudioBufferList before handing off to the
+  // worker thread; the consumer in taskOffloaderFunction frees it.
+  AudioBufferList *owned = copyAudioBufferList(audioBufferList);
+  if (owned == nullptr) {
+    return;
+  }
+
+  offloader_->getSender()->send({.audioBufferList = owned, .numFrames = numFrames});
 }
 
 void IOSFileWriter::taskOffloaderFunction(WriterData data)
 {
   auto [audioBufferList, numFrames] = data;
-  if (audioBufferList == nullptr)
+  if (audioBufferList == nullptr) {
     return;
+  }
   @autoreleasepool {
     NSError *error = nil;
+
+    for (size_t i = 0; i < bufferFormat_.channelCount; ++i) {
+      memcpy(
+          converterInputBuffer_.mutableAudioBufferList->mBuffers[i].mData,
+          audioBufferList->mBuffers[i].mData,
+          audioBufferList->mBuffers[i].mDataByteSize);
+    }
+
+    freeOwnedAudioBufferList(audioBufferList);
+    audioBufferList = nullptr;
+    converterInputBuffer_.frameLength = numFrames;
+
     AVAudioFormat *fileFormat = [audioFile_ processingFormat];
 
     if (bufferFormat_.sampleRate == fileFormat.sampleRate &&
         bufferFormat_.channelCount == fileFormat.channelCount &&
         bufferFormat_.isInterleaved == fileFormat.isInterleaved) {
-      // We can use the converter input buffer as a "transport" layer to the file
-      for (size_t i = 0; i < bufferFormat_.channelCount; ++i) {
-        memcpy(
-            converterInputBuffer_.mutableAudioBufferList->mBuffers[i].mData,
-            audioBufferList->mBuffers[i].mData,
-            audioBufferList->mBuffers[i].mDataByteSize);
-      }
-
-      audioBufferList = nullptr;
-      converterInputBuffer_.frameLength = numFrames;
-
       [audioFile_ writeFromBuffer:converterInputBuffer_ error:&error];
 
       if (error != nil) {
@@ -197,16 +212,6 @@ void IOSFileWriter::taskOffloaderFunction(WriterData data)
       framesWritten_.fetch_add(numFrames, std::memory_order_acq_rel);
       return;
     }
-
-    for (size_t i = 0; i < bufferFormat_.channelCount; ++i) {
-      memcpy(
-          converterInputBuffer_.mutableAudioBufferList->mBuffers[i].mData,
-          audioBufferList->mBuffers[i].mData,
-          audioBufferList->mBuffers[i].mDataByteSize);
-    }
-
-    audioBufferList = nullptr;
-    converterInputBuffer_.frameLength = numFrames;
 
     __block BOOL handedOff = false;
     AVAudioConverterInputBlock inputBlock = ^AVAudioBuffer *_Nullable(
@@ -223,13 +228,16 @@ void IOSFileWriter::taskOffloaderFunction(WriterData data)
     };
 
     [converter_ convertToBuffer:converterOutputBuffer_ error:&error withInputFromBlock:inputBlock];
-    converterOutputBuffer_.frameLength =
-        fileProperties_->sampleRate / bufferFormat_.sampleRate * numFrames;
 
     if (error != nil) {
       invokeOnErrorCallback(
           std::string("Error during audio conversion, native error: ") +
           [[error debugDescription] UTF8String]);
+      return;
+    }
+
+    AVAudioFrameCount producedFrames = converterOutputBuffer_.frameLength;
+    if (producedFrames == 0) {
       return;
     }
 
@@ -242,14 +250,14 @@ void IOSFileWriter::taskOffloaderFunction(WriterData data)
       return;
     }
 
-    framesWritten_.fetch_add(numFrames, std::memory_order_acq_rel);
+    framesWritten_.fetch_add(producedFrames, std::memory_order_acq_rel);
   }
 }
 
 double IOSFileWriter::getCurrentDuration() const
 {
   return static_cast<double>(framesWritten_.load(std::memory_order_acquire)) /
-      bufferFormat_.sampleRate;
+      fileProperties_->sampleRate;
 }
 
 std::string IOSFileWriter::getFilePath() const

--- a/packages/react-native-audio-api/ios/audioapi/ios/core/utils/IOSRecorderCallback.mm
+++ b/packages/react-native-audio-api/ios/audioapi/ios/core/utils/IOSRecorderCallback.mm
@@ -6,17 +6,18 @@
 #include <audioapi/dsp/VectorMath.h>
 #include <audioapi/events/AudioEventHandlerRegistry.h>
 #include <audioapi/ios/core/utils/IOSRecorderCallback.h>
+#include <audioapi/ios/core/utils/OwnedAudioBufferList.h>
 #include <audioapi/utils/AudioArray.hpp>
 #include <audioapi/utils/AudioBuffer.hpp>
 #include <audioapi/utils/CircularArray.hpp>
 #include <audioapi/utils/Result.hpp>
-#include <algorithm>
-#include <cstdlib>
-#include <cstring>
 #include <memory>
 #include <utility>
 
 namespace audioapi {
+
+using ios::copyAudioBufferList;
+using ios::freeOwnedAudioBufferList;
 
 IOSRecorderCallback::IOSRecorderCallback(
     const std::shared_ptr<AudioEventHandlerRegistry> &audioEventHandlerRegistry,
@@ -118,17 +119,6 @@ void IOSRecorderCallback::cleanup()
   }
 }
 
-static inline void freeOwnedAudioBufferList(const AudioBufferList *bufferList)
-{
-  if (bufferList == nullptr) {
-    return;
-  }
-  for (UInt32 i = 0; i < bufferList->mNumberBuffers; ++i) {
-    std::free(bufferList->mBuffers[i].mData);
-  }
-  std::free(const_cast<AudioBufferList *>(bufferList));
-}
-
 /// @brief Receives audio data from the recorder, processes it, and stores it in the circular buffer.
 /// The data is converted using AVAudioConverter if the input format differs from the user desired callback format.
 /// This method runs on the audio thread.
@@ -148,27 +138,9 @@ void IOSRecorderCallback::receiveAudioData(const AudioBufferList *audioBufferLis
   // CoreAudio owns `audioBufferList` only for the duration of this synchronous
   // callback. Copy into an owned AudioBufferList before handing off to the
   // worker thread; the consumer in taskOffloaderFunction frees it.
-  UInt32 bufferCount = audioBufferList->mNumberBuffers;
-  size_t headerSize = offsetof(AudioBufferList, mBuffers) + sizeof(AudioBuffer) * bufferCount;
-  AudioBufferList *owned = static_cast<AudioBufferList *>(std::malloc(headerSize));
+  AudioBufferList *owned = copyAudioBufferList(audioBufferList);
   if (owned == nullptr) {
     return;
-  }
-  owned->mNumberBuffers = bufferCount;
-  for (UInt32 i = 0; i < bufferCount; ++i) {
-    UInt32 byteSize = audioBufferList->mBuffers[i].mDataByteSize;
-    owned->mBuffers[i].mNumberChannels = audioBufferList->mBuffers[i].mNumberChannels;
-    owned->mBuffers[i].mDataByteSize = byteSize;
-    void *channelData = std::malloc(byteSize);
-    if (channelData == nullptr) {
-      for (UInt32 j = 0; j < i; ++j) {
-        std::free(owned->mBuffers[j].mData);
-      }
-      std::free(owned);
-      return;
-    }
-    std::memcpy(channelData, audioBufferList->mBuffers[i].mData, byteSize);
-    owned->mBuffers[i].mData = channelData;
   }
   offloader_->getSender()->send({.audioBufferList = owned, .numFrames = numFrames});
 }
@@ -236,13 +208,6 @@ void IOSRecorderCallback::taskOffloaderFunction(CallbackData data)
       return;
     }
 
-    // `convertToBuffer` sets `frameLength` to the number of frames it actually
-    // produced. The sample-rate converter's filter phase makes this fluctuate
-    // around `numFrames * ratio` from call to call, so pushing a computed
-    // estimate (the previous `ceil(...)`) reads stale samples from the end of
-    // the output buffer whenever the converter produced fewer frames —
-    // an audible click at the boundary of nearly every render block when the
-    // hardware rate differs from the requested callback rate.
     AVAudioFrameCount producedFrames = converterOutputBuffer_.frameLength;
     if (producedFrames == 0) {
       return;

--- a/packages/react-native-audio-api/ios/audioapi/ios/core/utils/IOSRecorderCallback.mm
+++ b/packages/react-native-audio-api/ios/audioapi/ios/core/utils/IOSRecorderCallback.mm
@@ -202,8 +202,6 @@ void IOSRecorderCallback::taskOffloaderFunction(CallbackData data)
       return;
     }
 
-    size_t outputFrameCount = ceil(numFrames * (sampleRate_ / bufferFormat_.sampleRate));
-
     for (size_t i = 0; i < bufferFormat_.channelCount; ++i) {
       memcpy(
           converterInputBuffer_.mutableAudioBufferList->mBuffers[i].mData,
@@ -230,7 +228,6 @@ void IOSRecorderCallback::taskOffloaderFunction(CallbackData data)
     };
 
     [converter_ convertToBuffer:converterOutputBuffer_ error:&error withInputFromBlock:inputBlock];
-    converterOutputBuffer_.frameLength = sampleRate_ / bufferFormat_.sampleRate * numFrames;
 
     if (error != nil) {
       invokeOnErrorCallback(
@@ -239,9 +236,21 @@ void IOSRecorderCallback::taskOffloaderFunction(CallbackData data)
       return;
     }
 
+    // `convertToBuffer` sets `frameLength` to the number of frames it actually
+    // produced. The sample-rate converter's filter phase makes this fluctuate
+    // around `numFrames * ratio` from call to call, so pushing a computed
+    // estimate (the previous `ceil(...)`) reads stale samples from the end of
+    // the output buffer whenever the converter produced fewer frames —
+    // an audible click at the boundary of nearly every render block when the
+    // hardware rate differs from the requested callback rate.
+    AVAudioFrameCount producedFrames = converterOutputBuffer_.frameLength;
+    if (producedFrames == 0) {
+      return;
+    }
+
     for (int i = 0; i < channelCount_; ++i) {
       auto *data = static_cast<float *>(converterOutputBuffer_.audioBufferList->mBuffers[i].mData);
-      circularBuffer_[i]->push_back(data, outputFrameCount);
+      circularBuffer_[i]->push_back(data, producedFrames);
     }
 
     if (circularBuffer_[0]->getNumberOfAvailableFrames() >= bufferLength_) {

--- a/packages/react-native-audio-api/ios/audioapi/ios/core/utils/IOSRotatingFileWriter.mm
+++ b/packages/react-native-audio-api/ios/audioapi/ios/core/utils/IOSRotatingFileWriter.mm
@@ -60,7 +60,6 @@ void IOSRotatingFileWriter::writeAudioData(AudioDataType data, int numFrames)
       rotateFiles();
     }
   }
-  framesWritten_.fetch_add(numFrames, std::memory_order_relaxed);
 }
 
 CloseFileResult IOSRotatingFileWriter::closeFile()
@@ -76,8 +75,11 @@ void IOSRotatingFileWriter::rotateFiles()
 
 double IOSRotatingFileWriter::getCurrentDuration() const
 {
-  return static_cast<double>(framesWritten_.load(std::memory_order_relaxed)) /
-      fileProperties_->sampleRate;
+  double currentSegmentDuration = 0.0;
+  if (currentWriter_ != nullptr) {
+    currentSegmentDuration = currentWriter_->getCurrentDuration();
+  }
+  return cumulativeDurationSec_ + currentSegmentDuration;
 }
 
 OpenFileResult IOSRotatingFileWriter::openInnerWriter()

--- a/packages/react-native-audio-api/ios/audioapi/ios/core/utils/OwnedAudioBufferList.h
+++ b/packages/react-native-audio-api/ios/audioapi/ios/core/utils/OwnedAudioBufferList.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#ifndef __OBJC__
+typedef struct AudioBufferList AudioBufferList;
+#endif
+
+namespace audioapi::ios {
+
+/// Frees an AudioBufferList allocated by `copyAudioBufferList`.
+void freeOwnedAudioBufferList(const AudioBufferList *bufferList);
+
+/// Deep-copies a Core Audio buffer list so it can outlive a synchronous I/O callback.
+/// Returns nullptr on allocation failure. Caller must free with `freeOwnedAudioBufferList`.
+AudioBufferList *copyAudioBufferList(const AudioBufferList *audioBufferList);
+
+} // namespace audioapi::ios

--- a/packages/react-native-audio-api/ios/audioapi/ios/core/utils/OwnedAudioBufferList.mm
+++ b/packages/react-native-audio-api/ios/audioapi/ios/core/utils/OwnedAudioBufferList.mm
@@ -1,0 +1,53 @@
+#import <CoreAudio/CoreAudioTypes.h>
+
+#include <audioapi/ios/core/utils/OwnedAudioBufferList.h>
+
+#include <cstddef>
+#include <cstdlib>
+#include <cstring>
+
+namespace audioapi::ios {
+
+void freeOwnedAudioBufferList(const AudioBufferList *bufferList)
+{
+  if (bufferList == nullptr) {
+    return;
+  }
+  for (UInt32 i = 0; i < bufferList->mNumberBuffers; ++i) {
+    std::free(bufferList->mBuffers[i].mData);
+  }
+  std::free(const_cast<AudioBufferList *>(bufferList));
+}
+
+AudioBufferList *copyAudioBufferList(const AudioBufferList *audioBufferList)
+{
+  if (audioBufferList == nullptr) {
+    return nullptr;
+  }
+
+  UInt32 bufferCount = audioBufferList->mNumberBuffers;
+  size_t headerSize = offsetof(AudioBufferList, mBuffers) + sizeof(AudioBuffer) * bufferCount;
+  auto *owned = static_cast<AudioBufferList *>(std::malloc(headerSize));
+  if (owned == nullptr) {
+    return nullptr;
+  }
+  owned->mNumberBuffers = bufferCount;
+  for (UInt32 i = 0; i < bufferCount; ++i) {
+    UInt32 byteSize = audioBufferList->mBuffers[i].mDataByteSize;
+    owned->mBuffers[i].mNumberChannels = audioBufferList->mBuffers[i].mNumberChannels;
+    owned->mBuffers[i].mDataByteSize = byteSize;
+    void *channelData = std::malloc(byteSize);
+    if (channelData == nullptr) {
+      for (UInt32 j = 0; j < i; ++j) {
+        std::free(owned->mBuffers[j].mData);
+      }
+      std::free(owned);
+      return nullptr;
+    }
+    std::memcpy(channelData, audioBufferList->mBuffers[i].mData, byteSize);
+    owned->mBuffers[i].mData = channelData;
+  }
+  return owned;
+}
+
+} // namespace audioapi::ios


### PR DESCRIPTION
Closes #1096

## ⚠️ Breaking changes ⚠️

None.

## Introduced changes

- `IOSRecorderCallback::taskOffloaderFunction` now pushes `converterOutputBuffer_.frameLength` — the frame count `AVAudioConverter` actually produced — into the circular buffer, instead of a `ceil(numFrames * ratio)` estimate.
- Removed the post-conversion `converterOutputBuffer_.frameLength = ...` assignment that was overwriting the converter's real output count with that estimate.
- Early-return when the converter produced zero frames.

### Why

The SRC's filter phase makes per-call output fluctuate around `numFrames * ratio` (a 512-frame block at 48 kHz → 16 kHz yields 170 or 171 frames depending on accumulated phase). Whenever the converter produced fewer frames than the `ceil()` estimate, the extra pushed samples were stale data from a previous render block — a single-sample impulse (audible click) at nearly every block boundary, in every recording where the requested `onAudioReady` sample rate differs from the hardware input rate. Full analysis with PCM evidence in #1096.

Android is unaffected: `AndroidRecorderCallback` already uses the produced count reported by `ma_data_converter_process_pcm_frames`.

## Checklist

- [x] Linked relevant issue
- [ ] Updated relevant documentation — n/a, no API change
- [x] Added/Conducted relevant tests — verified in a production app: this fix (applied as a local patch) eliminates the periodic impulses from recorded PCM; before/after waveform analysis in #1096
- [x] Performed self-review of the code
- [ ] Updated Web Audio API coverage — n/a
- [ ] Added support for web — n/a, iOS-only bug fix
- [ ] Updated old arch android spec file — n/a
