### PR TITLE
test: assert AudioBufferQueueSourceNode consumes frames at 1x pace with gapless streaming output

### DIFF
--- a/packages/react-native-audio-api/common/cpp/test/src/core/sources/AudioBufferQueueSourceTest.cpp
+++ b/packages/react-native-audio-api/common/cpp/test/src/core/sources/AudioBufferQueueSourceTest.cpp
@@ -1,0 +1,208 @@
+#include <audioapi/core/OfflineAudioContext.h>
+#include <audioapi/core/destinations/AudioDestinationNode.h>
+#include <audioapi/core/sources/AudioBufferQueueSourceNode.h>
+#include <audioapi/core/utils/Constants.h>
+#include <audioapi/core/utils/worklets/SafeIncludes.h>
+#include <audioapi/types/NodeOptions.h>
+#include <audioapi/utils/AudioArray.hpp>
+#include <audioapi/utils/AudioBuffer.hpp>
+#include <gtest/gtest.h>
+#include <test/src/MockAudioEventHandlerRegistry.h>
+#include <memory>
+#include <vector>
+
+using namespace audioapi;
+
+// NOLINTBEGIN
+
+namespace {
+
+constexpr int SAMPLE_RATE = 24000;
+constexpr int QUANTUM = RENDER_QUANTUM_SIZE;
+
+/// Builds a mono AudioBuffer of `frames` frames whose samples continue a
+/// global ramp: sample k holds the value (startValue + k) * 1e-6f. Feeding
+/// consecutive ramp buffers lets assertions detect skipped frames, repeated
+/// frames, and stale/garbage samples in a single pass.
+std::shared_ptr<AudioBuffer> makeRampBuffer(size_t frames, size_t startValue) {
+  auto buffer = std::make_shared<AudioBuffer>(frames, 1, (float)SAMPLE_RATE);
+  auto channel = buffer->getChannel(0)->span();
+  for (size_t i = 0; i < frames; ++i) {
+    channel[i] = static_cast<float>(startValue + i) * 1e-6f;
+  }
+  return buffer;
+}
+
+class TestableQueueSourceNode : public AudioBufferQueueSourceNode {
+ public:
+  explicit TestableQueueSourceNode(const std::shared_ptr<BaseAudioContext> &context)
+      : AudioBufferQueueSourceNode(context, BaseAudioBufferSourceOptions()) {}
+
+  using AudioBufferQueueSourceNode::getCurrentPosition;
+  using AudioBufferQueueSourceNode::processNode;
+};
+
+} // namespace
+
+class AudioBufferQueueSourceTest : public ::testing::Test {
+ protected:
+  std::shared_ptr<MockAudioEventHandlerRegistry> eventRegistry;
+  std::shared_ptr<OfflineAudioContext> context;
+
+  void SetUp() override {
+    eventRegistry = std::make_shared<MockAudioEventHandlerRegistry>();
+    context = std::make_shared<OfflineAudioContext>(
+        1, 5 * SAMPLE_RATE, SAMPLE_RATE, eventRegistry, RuntimeRegistry{});
+    context->initialize();
+  }
+
+  /// Renders one quantum from `node` and advances the context clock the way
+  /// AudioDestinationNode::renderAudio does in production (process first,
+  /// then advance currentSampleFrame).
+  std::shared_ptr<DSPAudioBuffer> renderQuantum(TestableQueueSourceNode &node) {
+    auto out = std::make_shared<DSPAudioBuffer>(QUANTUM, 1, (float)SAMPLE_RATE);
+    out->zero();
+    auto result = node.processNode(out, QUANTUM);
+    auto clockBuffer = std::make_shared<DSPAudioBuffer>(QUANTUM, 1, (float)SAMPLE_RATE);
+    context->getDestination()->renderAudio(clockBuffer, QUANTUM);
+    return result;
+  }
+};
+
+/// Frame-consumption pace: rendering N quanta must consume exactly N * 128
+/// source frames — the symptom in #1064 is consumption ~3x faster than
+/// real time.
+TEST_F(AudioBufferQueueSourceTest, ConsumesExactlyOneFramePerRenderedFrame) {
+  TestableQueueSourceNode node(context);
+
+  // 3 buffers x 1000 frames; 1000 % 128 != 0 exercises the cross-buffer path.
+  constexpr size_t BUFFER_FRAMES = 1000;
+  constexpr size_t BUFFER_COUNT = 3;
+  for (size_t b = 0; b < BUFFER_COUNT; ++b) {
+    node.enqueueBuffer(makeRampBuffer(BUFFER_FRAMES, b * BUFFER_FRAMES), b, nullptr);
+  }
+
+  node.start(0.0);
+
+  constexpr size_t TOTAL_FRAMES = BUFFER_FRAMES * BUFFER_COUNT;
+  size_t expected = 0;
+
+  while (expected + QUANTUM <= TOTAL_FRAMES) {
+    auto out = renderQuantum(node);
+    ASSERT_NE(out, nullptr);
+    auto channel = out->getChannel(0)->span();
+    for (int i = 0; i < QUANTUM; ++i) {
+      ASSERT_FLOAT_EQ(channel[i], static_cast<float>(expected + i) * 1e-6f)
+          << "Discontinuity at global frame " << (expected + i)
+          << " — source consumed frames at the wrong pace or emitted garbage";
+    }
+    expected += QUANTUM;
+  }
+
+  // Position must track rendered time 1:1 (the #1064 report measured ~3x).
+  const double expectedPosition = static_cast<double>(expected) / SAMPLE_RATE;
+  EXPECT_NEAR(node.getCurrentPosition(), expectedPosition, 2.0 * QUANTUM / (double)SAMPLE_RATE);
+}
+
+/// Streaming pattern from the #1064 report: chunks are enqueued while the
+/// node is already playing (TTS over WebSocket). Content must stay gapless
+/// and at 1x pace across enqueues that race buffer exhaustion.
+TEST_F(AudioBufferQueueSourceTest, StreamingEnqueueKeepsPaceAndContinuity) {
+  TestableQueueSourceNode node(context);
+
+  constexpr size_t CHUNK_FRAMES = 10080; // 420ms @ 24kHz, matches the report
+  size_t produced = 0;
+  size_t chunkId = 0;
+
+  node.enqueueBuffer(makeRampBuffer(CHUNK_FRAMES, produced), chunkId++, nullptr);
+  produced += CHUNK_FRAMES;
+
+  node.start(0.0);
+
+  size_t expected = 0;
+  // Render ~2.1s of audio, feeding a new chunk roughly every 0.42s of
+  // rendered time, just like a realtime TTS stream would.
+  constexpr size_t TOTAL_QUANTA = 400;
+  for (size_t q = 0; q < TOTAL_QUANTA; ++q) {
+    // Keep ~1 chunk of headroom queued, mirroring realtime arrival.
+    if (expected + CHUNK_FRAMES > produced) {
+      node.enqueueBuffer(makeRampBuffer(CHUNK_FRAMES, produced), chunkId++, nullptr);
+      produced += CHUNK_FRAMES;
+    }
+
+    auto out = renderQuantum(node);
+    ASSERT_NE(out, nullptr);
+    auto channel = out->getChannel(0)->span();
+    for (int i = 0; i < QUANTUM; ++i) {
+      ASSERT_FLOAT_EQ(channel[i], static_cast<float>(expected + i) * 1e-6f)
+          << "Discontinuity at global frame " << (expected + i) << " (quantum " << q << ")";
+    }
+    expected += QUANTUM;
+  }
+
+  const double expectedPosition = static_cast<double>(expected) / SAMPLE_RATE;
+  EXPECT_NEAR(node.getCurrentPosition(), expectedPosition, 2.0 * QUANTUM / (double)SAMPLE_RATE);
+}
+
+/// Full-graph variant: a mono queue source created via the context factory,
+/// connected to the (stereo) destination, rendered through
+/// AudioDestinationNode::renderAudio — i.e. the exact production pull path
+/// including graph pre-processing, channel up-mixing and the destination's
+/// per-quantum normalize(). Content is an impulse train (1.0 every 1000
+/// frames); after normalization the impulse POSITIONS must still land every
+/// 1000 output frames if consumption pace is exactly 1x, and every other
+/// sample must stay silent.
+TEST_F(AudioBufferQueueSourceTest, FullGraphRenderPreservesPaceAndSilence) {
+  auto stereoContext = std::make_shared<OfflineAudioContext>(
+      2, 5 * SAMPLE_RATE, SAMPLE_RATE, eventRegistry, RuntimeRegistry{});
+  stereoContext->initialize();
+
+  auto node = stereoContext->createBufferQueueSource(BaseAudioBufferSourceOptions());
+  node->connect(stereoContext->getDestination());
+
+  constexpr size_t CHUNK_FRAMES = 10080;
+  constexpr size_t IMPULSE_PERIOD = 1000;
+  size_t produced = 0;
+  size_t chunkId = 0;
+
+  auto makeImpulseChunk = [&]() {
+    auto buffer = std::make_shared<AudioBuffer>(CHUNK_FRAMES, 1, (float)SAMPLE_RATE);
+    auto channel = buffer->getChannel(0)->span();
+    for (size_t i = 0; i < CHUNK_FRAMES; ++i) {
+      channel[i] = ((produced + i) % IMPULSE_PERIOD == 0) ? 1.0f : 0.0f;
+    }
+    node->enqueueBuffer(buffer, chunkId++, nullptr);
+    produced += CHUNK_FRAMES;
+  };
+
+  makeImpulseChunk();
+  node->start(0.0);
+
+  size_t rendered = 0;
+  constexpr size_t TOTAL_QUANTA = 400;
+  for (size_t q = 0; q < TOTAL_QUANTA; ++q) {
+    if (rendered + CHUNK_FRAMES > produced) {
+      makeImpulseChunk();
+    }
+
+    auto out = std::make_shared<DSPAudioBuffer>(QUANTUM, 2, (float)SAMPLE_RATE);
+    stereoContext->getDestination()->renderAudio(out, QUANTUM);
+
+    for (size_t ch = 0; ch < 2; ++ch) {
+      auto channel = out->getChannel(ch)->span();
+      for (int i = 0; i < QUANTUM; ++i) {
+        const size_t globalFrame = rendered + i;
+        if (globalFrame % IMPULSE_PERIOD == 0) {
+          ASSERT_GT(channel[i], 0.5f) << "Missing impulse at frame " << globalFrame << " ch " << ch
+                                      << " — source consumed frames at the wrong pace";
+        } else {
+          ASSERT_NEAR(channel[i], 0.0f, 1e-6f)
+              << "Garbage at frame " << globalFrame << " ch " << ch;
+        }
+      }
+    }
+    rendered += QUANTUM;
+  }
+}
+
+// NOLINTEND


### PR DESCRIPTION
References #1064 (does not close it — see below).

## ⚠️ Breaking changes ⚠️

None — test-only change.

## Introduced changes

Adds offline-render regression coverage for the `AudioBufferQueueSourceNode` contract reported broken in #1064 (streamed PCM playing at ~3× speed with heavy static on iOS 0.12.x):

- **`ConsumesExactlyOneFramePerRenderedFrame`** — rendering a ramp spread across multiple queued buffers must reproduce every source frame exactly once, one frame per rendered frame, including across buffer boundaries that don't align with the render quantum (1000-frame buffers vs 128-frame quanta). Also asserts `getCurrentPosition()` tracks rendered time 1:1 (the #1064 report measured ~3×).
- **`StreamingEnqueueKeepsPaceAndContinuity`** — the realtime TTS streaming pattern from the report (24 kHz mono chunks of 10080 frames enqueued while the node is playing) must stay gapless and at 1× pace.
- **`FullGraphRenderPreservesPaceAndSilence`** — the full production pull path (factory-created node → `connect` to a stereo destination → `AudioDestinationNode::renderAudio`, including graph pre-processing, mono→stereo up-mix, and the destination's per-quantum `normalize()`). An impulse train every 1000 frames must keep its impulse positions and inter-impulse silence in both output channels.

### Relation to #1064

All three tests **pass on current `main`**, so they don't reproduce the bug — instead they pin the contract and narrow the search: the shared C++ render core (queue node, scheduling, graph pull, destination) consumes at exactly 1× with clean output in offline rendering. Combined with the report (broken on 0.12.x device **and** simulator, clean on 0.11.7), the regression most likely lives in the iOS platform integration layer (`AVAudioSourceNode` / engine wiring) or in 0.12.1-era code that has since been refactored. I've posted the detailed findings on the issue.

## Checklist

- [x] Linked relevant issue
- [ ] Updated relevant documentation — n/a, test-only
- [x] Added/Conducted relevant tests — `tests` target: 272 passed including the 3 new ones; file passes `format:check:common`
- [x] Performed self-review of the code
- [ ] Updated Web Audio API coverage — n/a
- [ ] Added support for web — n/a
- [ ] Updated old arch android spec file — n/a
