### PR TITLE
Fix android crash when recording repeated sessions

### DIFF
--- a/.claude/skills/post-work-checks/SKILL.md
+++ b/.claude/skills/post-work-checks/SKILL.md
@@ -56,6 +56,14 @@ Runs `packages/react-native-audio-api/common/cpp/test/RunTests.sh` via CMake + G
 
 **When**: after any change to `common/cpp/audioapi/core/`, `dsp/`, or `utils/` C++ files.
 
+### Android C++ compile check
+
+```bash
+cd apps/fabric-example/android && ./gradlew :react-native-audio-api:assembleDebug
+```
+
+**When**: after any change to `android/src/main/cpp/` — these files are NOT covered by `yarn test` (which only builds `common/cpp/`). The gradle project resolves through the `node_modules/react-native-audio-api` workspace symlink, so local edits in `packages/react-native-audio-api/` are picked up. Takes ~3-4 minutes.
+
 ### AudioEvent enum sync check
 
 ```bash

--- a/packages/react-native-audio-api/android/src/main/cpp/audioapi/android/core/AndroidAudioRecorder.cpp
+++ b/packages/react-native-audio-api/android/src/main/cpp/audioapi/android/core/AndroidAudioRecorder.cpp
@@ -199,7 +199,8 @@ AndroidAudioRecorder::stop() {
 
     if (usesCallback()) {
       callbackOutputConfigured_.store(false, std::memory_order_release);
-      dataCallback = std::move(dataCallback_);
+      // Keep the JS callback subscription registered across stop/start cycles.
+      dataCallback = dataCallback_;
     }
 
     if (isConnected()) {

--- a/packages/react-native-audio-api/android/src/main/cpp/audioapi/android/core/utils/ffmpegBackend/FFmpegFileWriter.cpp
+++ b/packages/react-native-audio-api/android/src/main/cpp/audioapi/android/core/utils/ffmpegBackend/FFmpegFileWriter.cpp
@@ -112,6 +112,8 @@ CloseFileResult FFmpegAudioFileWriter::closeFile() {
     return CloseFileResult::Err("File is not open");
   }
 
+  offloader_.reset();
+
   result = processFifo(true);
 
   if (result < 0) {
@@ -127,7 +129,6 @@ CloseFileResult FFmpegAudioFileWriter::closeFile() {
   if (writeEncodedPackets() < 0) {
     return CloseFileResult::Err("Failed to drain encoder packets");
   }
-  offloader_.reset();
 
   return finalizeOutput();
 }


### PR DESCRIPTION
## Introduced changes

### Symptoms

I hit an Android-only crash/freeze and follow-on callback-output failure when using `AudioRecorder` with file output (`.m4a`, FFmpeg enabled) and callback output across repeated recording sessions.

In my app, the first recording could start, stop, and save, but repeated recording sessions exposed two related Android failures:

1. An outright app crash/freeze during or shortly after stopping/saving a recording.
2. After addressing/retrying that path, subsequent recording attempts could fail with:

```text
Callback output is unavailable
```

The user-facing results were either a frozen/crashed app, a recording that could not be saved, or a saved recording with `0:00` captured duration.

### Validation

After applying this patch locally, I tested repeated recordings on a physical Android device:

1. Start recording
2. Record for ~1 minute
3. Stop recording
4. Save recording
5. Repeat by starting a new recording

Results:

- No app crash/freeze during stop/save
- No `Callback output is unavailable` log
- No `SIGABRT`, `SIGSEGV`, or `crash_dump`
- AudioFlinger showed the record track released after save
- The app showed nonzero captured durations for repeated recordings

This PR fixes both the original crash/freeze and the later callback-output failure.

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added/Conducted relevant tests
- [x] Performed self-review of the code
- [ ] Updated Web Audio API coverage N/A
- [ ] Added support for web N/A
- [ ] Updated old arch android spec file N/A
