### PR TITLE
fix(ios): avoid WorkletsModule.h import that breaks worklets-enabled builds

### DIFF
--- a/packages/react-native-audio-api/RNAudioAPI.podspec
+++ b/packages/react-native-audio-api/RNAudioAPI.podspec
@@ -99,7 +99,11 @@ Pod::Spec.new do |s|
       "\"$(PODS_TARGET_SRCROOT)/#{external_dir_relative}/include/vorbis\""
     ])
     .concat($RN_AUDIO_API_FFMPEG_DISABLED ? [] : ["\"$(PODS_TARGET_SRCROOT)/#{external_dir_relative}/include_ffmpeg\""])
-    .concat(worklets_enabled ? ['"$(PODS_ROOT)/Headers/Public/RNWorklets"'] : [])
+    .concat(worklets_enabled ? [
+      '"$(PODS_ROOT)/Headers/Public/RNWorklets"',
+      '"$(PODS_ROOT)/Headers/Private/ReactCodegen"',
+      '"$(PODS_ROOT)/../build/generated/ios/ReactCodegen"',
+    ] : [])
     .join(' '),
     "CLANG_CXX_LANGUAGE_STANDARD" => "c++20",
     "GCC_PREPROCESSOR_DEFINITIONS" => '$(inherited) HAVE_ACCELERATE=1',
@@ -120,6 +124,8 @@ Pod::Spec.new do |s|
     ]
     .concat(worklets_enabled ? [
       '"$(PODS_ROOT)/Headers/Public/RNWorklets"',
+      '"$(PODS_ROOT)/Headers/Private/ReactCodegen"',
+      '"$(PODS_ROOT)/../build/generated/ios/ReactCodegen"',
       "\"$(PODS_ROOT)/#{$audio_api_config[:dynamic_frameworks_worklets_dir]}/apple\"",
       "\"$(PODS_ROOT)/#{$audio_api_config[:dynamic_frameworks_worklets_dir]}/Common/cpp\""
     ] : [])

--- a/packages/react-native-audio-api/ios/audioapi/ios/AudioAPIModule.mm
+++ b/packages/react-native-audio-api/ios/audioapi/ios/AudioAPIModule.mm
@@ -3,7 +3,13 @@
 
 #import <audioapi/core/utils/worklets/SafeIncludes.h>
 #if RN_AUDIO_API_ENABLE_WORKLETS
-#import <worklets/apple/WorkletsModule.h>
+// Forward-declare the single method used from WorkletsModule instead of importing
+// <worklets/apple/WorkletsModule.h>, which transitively includes the codegen-generated
+// <rnworklets/rnworklets.h> that is not visible to this compile unit in all build setups
+// (e.g. prebuilt RNWorklets in EAS builds).
+@interface WorkletsModule : NSObject
+- (std::shared_ptr<worklets::WorkletsModuleProxy>)getWorkletsModuleProxy;
+@end
 #endif
 #ifdef RCT_NEW_ARCH_ENABLED
 #import <React/RCTCallInvoker.h>


### PR DESCRIPTION
Fixes #1095

## Introduced changes

Building an app with react-native-worklets could fail compiling RNAudioAPI with "'rnworklets/rnworklets.h' file not found", because AudioAPIModule.mm imported <worklets/apple/WorkletsModule.h>, which transitively includes the codegen-generated rnworklets spec header that is not visible to the RNAudioAPI compile unit in all build setups (e.g. prebuilt RNWorklets on EAS builds).

- Forward-declare the single WorkletsModule method the file actually uses (getWorkletsModuleProxy) instead of importing the full header.
- Add ReactCodegen header search paths to the worklets-enabled HEADER_SEARCH_PATHS so generated spec headers remain resolvable.

## Checklist

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added/Conducted relevant tests
- [x] Performed self-review of the code
- [ ] Updated Web Audio API coverage N/A
- [ ] Added support for web N/A
- [ ] Updated old arch android spec file N/A
