### PR TITLE
fix(android): use 'category' key instead of 'type'

### DIFF
--- a/packages/react-native-audio-api/android/src/main/java/com/swmansion/audioapi/system/MediaSessionManager.kt
+++ b/packages/react-native-audio-api/android/src/main/java/com/swmansion/audioapi/system/MediaSessionManager.kt
@@ -211,7 +211,7 @@ object MediaSessionManager {
       val deviceInfo = Arguments.createMap()
       deviceInfo.putString("id", inputDevice.getId().toString())
       deviceInfo.putString("name", inputDevice.productName.toString())
-      deviceInfo.putString("type", parseDeviceType(inputDevice))
+      deviceInfo.putString("category", parseDeviceCategory(inputDevice))
 
       availableInputs.pushMap(deviceInfo)
     }
@@ -220,7 +220,7 @@ object MediaSessionManager {
       val deviceInfo = Arguments.createMap()
       deviceInfo.putString("id", outputDevice.getId().toString())
       deviceInfo.putString("name", outputDevice.productName.toString())
-      deviceInfo.putString("type", parseDeviceType(outputDevice))
+      deviceInfo.putString("category", parseDeviceCategory(outputDevice))
 
       availableOutputs.pushMap(deviceInfo)
     }
@@ -236,7 +236,7 @@ object MediaSessionManager {
   }
 
   @RequiresApi(Build.VERSION_CODES.O)
-  fun parseDeviceType(device: AudioDeviceInfo): String =
+  fun parseDeviceCategory(device: AudioDeviceInfo): String =
     when (device.type) {
       AudioDeviceInfo.TYPE_BUILTIN_MIC -> "Built-in Mic"
       AudioDeviceInfo.TYPE_BUILTIN_EARPIECE -> "Built-in Earpiece"


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #

When enumerating devices on Android the category field is empty, this is due to the fact that we use "type" instead of "category"

## ⚠️ Breaking changes ⚠️

<!-- A brief description of the breaking changes -->

-

## Introduced changes

<!-- A brief description of the changes -->

* Changed the key in the device info map from `"type"` to `"category"` when reporting both input and output audio devices.
* Renamed the function `parseDeviceType` to `parseDeviceCategory` to match the new terminology.

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [x] Added/Conducted relevant tests
- [x] Performed self-review of the code
- [ ] Updated Web Audio API coverage
- [ ] Added support for web
- [ ] Updated old arch android spec file
