### PR TITLE
Fix/engine race condition

### DIFF
--- a/.claude/skills/thread-safety-itc/SKILL.md
+++ b/.claude/skills/thread-safety-itc/SKILL.md
@@ -136,6 +136,21 @@ See the `utilities` skill for full API.
 
 ---
 
+## Driver synchronization (layered model)
+
+Control-plane synchronization uses two layers — both are non-recursive `std::mutex`, never held on the audio thread.
+
+| Layer | Location | Protects |
+|---|---|---|
+| Context | `AudioContext::driverMutex_` (iOS + Android) | `start` / `resume` / `suspend` / `close` only — JS-thread `source.start()` vs promise-pool `resume()` / `suspend()` / `close()` |
+| Engine | `AudioEngine` mutex (iOS only) | Process-wide `AVAudioEngine` graph: attach/detach, engine start/stop, interruptions, recorder paths |
+
+`AudioContext::initialize()`, `createMediaElementSource()`, and `isDriverRunning()` are JS-thread-only — do not take `driverMutex_`. `getState()` reads atomics and `isDriverRunning()` lock-free; do not acquire `driverMutex_` from there.
+
+On Android, `AudioPlayer::onErrorAfterClose` also takes `driverMutex_` because Oboe error callbacks bypass `AudioContext`.
+
+---
+
 ## Common Mistakes
 
 - **Reading `node_->field_` in a getter** when that field is written by the audio thread → use shadow state or atomics.
@@ -144,6 +159,9 @@ See the `utilities` skill for full API.
 - **`std::vector::push_back` in `processNode()`** → may allocate; preallocate in constructor.
 - **`std::mutex` anywhere in `processNode()`** → deadlock risk and real-time violation.
 - **Copying `shared_ptr` inside `processNode()`** — increments atomic refcount; capture before entering hot path.
+- **Locking `initialize()` or graph factory methods** — `initialize()` runs synchronously during HostObject construction on the JS thread; node factories and `createMediaElementSource()` are synchronous JS calls. Only `start` / `resume` / `suspend` / `close` need `driverMutex_`.
+- **Locking only `AudioContext`** — iOS recorder, session, and interruption paths mutate the shared `AVAudioEngine` outside `AudioContext`; keep the `AudioEngine` mutex on those entry points.
+- **Re-entering `driverMutex_` or the `AudioEngine` mutex on the same thread** — call `tryStartDriver()` directly from `resume()` instead of `start()`; use lock-free `isStreamRunning()` from `isDriverRunning()`.
 
 ---
 

--- a/apps/common-app/src/components/Slider.tsx
+++ b/apps/common-app/src/components/Slider.tsx
@@ -1,17 +1,10 @@
-import React, { useEffect } from 'react';
-import {
-  View,
-  Text,
-  TextInput,
-  StyleSheet,
-  LayoutChangeEvent,
-} from 'react-native';
+import React, { useCallback, useEffect, useState } from 'react';
+import { View, Text, StyleSheet, LayoutChangeEvent } from 'react-native';
 import { GestureDetector, Gesture } from 'react-native-gesture-handler';
 import Animated, {
   runOnJS,
   withSpring,
   useSharedValue,
-  useAnimatedProps,
   useAnimatedStyle,
 } from 'react-native-reanimated';
 
@@ -30,6 +23,11 @@ interface SliderProps {
 }
 
 const handleSize = 20;
+
+function formatSliderValue(value: number, step: number): string {
+  const rounded = Math.round(value / step) * step;
+  return step < 1 ? rounded.toFixed(2) : String(rounded);
+}
 
 function valueToOffset(
   value: number,
@@ -59,31 +57,43 @@ function roundToStep(value: number, step: number): number {
   return Math.round(value / step) * step;
 }
 
-const AnimatedText = Animated.createAnimatedComponent(TextInput);
-
 const Slider: React.FC<SliderProps> = (props) => {
   const { value, onValueChange, min, max, step, label, minLabelWidth } = props;
 
   const offset = useSharedValue(0);
   const sValue = useSharedValue(0);
   const sliderWidth = useSharedValue(0);
+  const [displayValue, setDisplayValue] = useState(() =>
+    formatSliderValue(value, step),
+  );
+
+  const syncDisplayValue = useCallback(
+    (nextValue: number) => {
+      setDisplayValue(formatSliderValue(nextValue, step));
+    },
+    [step],
+  );
 
   useEffect(() => {
     offset.value = valueToOffset(value, sliderWidth.value, min, max);
     sValue.value = value;
-  }, [value, min, max, sliderWidth, offset, sValue]);
+    setDisplayValue(formatSliderValue(value, step));
+  }, [value, min, max, step, sliderWidth, offset, sValue]);
 
   const pan = Gesture.Pan()
     .onChange((event) => {
       offset.value = Math.max(
         0,
-        Math.min(sliderWidth.value - handleSize, offset.value + event.changeX)
+        Math.min(sliderWidth.value - handleSize, offset.value + event.changeX),
       );
 
       sValue.value = offsetToValue(offset.value, sliderWidth.value, min, max);
+      runOnJS(syncDisplayValue)(sValue.value);
     })
     .onEnd(() => {
-      runOnJS(onValueChange)(roundToStep(sValue.value, step));
+      const rounded = roundToStep(sValue.value, step);
+      runOnJS(onValueChange)(rounded);
+      runOnJS(syncDisplayValue)(rounded);
     });
 
   const onSliderLayout = (event: LayoutChangeEvent) => {
@@ -93,10 +103,11 @@ const Slider: React.FC<SliderProps> = (props) => {
       value,
       event.nativeEvent.layout.width,
       min,
-      max
+      max,
     );
 
     sValue.value = value;
+    setDisplayValue(formatSliderValue(value, step));
   };
 
   const handleStyle = useAnimatedStyle(() => ({
@@ -109,18 +120,13 @@ const Slider: React.FC<SliderProps> = (props) => {
     ],
   }));
 
-  const valueTextProps = useAnimatedProps(() => ({
-    text: `${step < 1 ? roundToStep(sValue.value, step).toFixed(2) : roundToStep(sValue.value, step)}`,
-    defaultValue: `${roundToStep(sValue.value, step)}`,
-  }));
-
   const valueTextStyle = useAnimatedStyle(() => ({
     transform: [
       {
         translateX: withSpring(
           sliderWidth.value > 0 && offset.value < 1.5 * handleSize
             ? 1.5 * handleSize
-            : 0
+            : 0,
         ),
       },
     ],
@@ -143,11 +149,9 @@ const Slider: React.FC<SliderProps> = (props) => {
       <GestureDetector gesture={pan}>
         <View style={styles.slider} onLayout={onSliderLayout}>
           <Animated.View style={[styles.fill, fillStyle]} />
-          <AnimatedText
-            editable={false}
-            animatedProps={valueTextProps}
-            style={[styles.valueText, valueTextStyle]}
-          />
+          <Animated.View style={[styles.valueTextContainer, valueTextStyle]}>
+            <Text style={styles.valueText}>{displayValue}</Text>
+          </Animated.View>
           <Animated.View style={[styles.handle, handleStyle]} />
         </View>
       </GestureDetector>
@@ -180,16 +184,19 @@ const styles = StyleSheet.create({
     borderRadius: handleSize / 2,
     backgroundColor: colors.main,
   },
-  valueText: {
-    fontSize: 16,
-    fontWeight: '600',
-    color: colors.white,
+  valueTextContainer: {
     position: 'absolute',
     left: 0,
     right: 0,
     top: 0,
     bottom: 0,
+    justifyContent: 'center',
     paddingLeft: 12,
+  },
+  valueText: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: colors.white,
   },
   handle: {
     marginTop: -1,

--- a/apps/fabric-example/ios/FabricExampleTests/AudioEngineTests.mm
+++ b/apps/fabric-example/ios/FabricExampleTests/AudioEngineTests.mm
@@ -253,6 +253,11 @@
 
 @implementation AudioEngineTests
 
++ (BOOL)testInvocationsAreParallelizable
+{
+  return NO;
+}
+
 - (void)setUp {
   [super setUp];
 
@@ -909,6 +914,104 @@
   XCTAssertEqual(newEngine.startCallCount, 1);
   XCTAssertEqual(self.sessionManager.ensureActiveCallCount, 1);
   XCTAssertEqual(self.audioEngine.state, AudioEngineStateRunning);
+}
+
+- (void)testConcurrentStartIfNecessaryDoesNotCrash {
+  [self attachSourceNodeToAudioEngine];
+  self.audioEngine.state = AudioEngineStateIdle;
+
+  dispatch_queue_t queue =
+      dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0);
+  dispatch_group_t group = dispatch_group_create();
+
+  for (NSInteger index = 0; index < 20; index += 1) {
+    dispatch_group_enter(group);
+    dispatch_async(queue, ^{
+      [self.audioEngine startIfNecessary];
+      dispatch_group_leave(group);
+    });
+  }
+
+  dispatch_group_wait(group, dispatch_time(DISPATCH_TIME_NOW, 5 * NSEC_PER_SEC));
+  XCTAssertTrue([self.audioEngine startIfNecessary]);
+}
+
+- (void)testConcurrentAttachDetachAndRestartDoesNotCrash {
+  dispatch_queue_t queue =
+      dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0);
+  dispatch_group_t group = dispatch_group_create();
+
+  for (NSInteger index = 0; index < 10; index += 1) {
+    dispatch_group_enter(group);
+    dispatch_async(queue, ^{
+      NSString *sourceNodeId = [self attachSourceNodeToAudioEngine];
+      [self.audioEngine detachSourceNodeWithId:sourceNodeId];
+      dispatch_group_leave(group);
+    });
+  }
+
+  for (NSInteger index = 0; index < 5; index += 1) {
+    dispatch_group_enter(group);
+    dispatch_async(queue, ^{
+      [self.audioEngine restartAudioEngine];
+      dispatch_group_leave(group);
+    });
+  }
+
+  dispatch_group_wait(group, dispatch_time(DISPATCH_TIME_NOW, 5 * NSEC_PER_SEC));
+}
+
+- (void)testConcurrentRecordAndPlayPathsDoNotCrash {
+  [self attachSourceNodeToAudioEngine];
+
+  dispatch_queue_t queue =
+      dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0);
+  dispatch_group_t group = dispatch_group_create();
+
+  for (NSInteger index = 0; index < 10; index += 1) {
+    dispatch_group_enter(group);
+    dispatch_async(queue, ^{
+      [self.audioEngine attachInputNodeWithReceiverBlock:[self testInputReceiverBlock]];
+      [self.audioEngine startIfNecessary];
+      dispatch_group_leave(group);
+    });
+
+    dispatch_group_enter(group);
+    dispatch_async(queue, ^{
+      [self attachSourceNodeToAudioEngine];
+      [self.audioEngine startIfNecessary];
+      dispatch_group_leave(group);
+    });
+  }
+
+  dispatch_group_wait(group, dispatch_time(DISPATCH_TIME_NOW, 5 * NSEC_PER_SEC));
+}
+
+- (void)testConcurrentInterruptionAndStartDoesNotCrash {
+  [self attachSourceNodeToAudioEngine];
+  self.audioEngine.state = AudioEngineStateRunning;
+  self.audioEngine.currentFakeAudioEngine.fakeRunning = YES;
+
+  dispatch_queue_t queue =
+      dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0);
+  dispatch_group_t group = dispatch_group_create();
+
+  for (NSInteger index = 0; index < 10; index += 1) {
+    dispatch_group_enter(group);
+    dispatch_async(queue, ^{
+      [self.audioEngine onInterruptionBegin];
+      [self.audioEngine onInterruptionEnd:true];
+      dispatch_group_leave(group);
+    });
+
+    dispatch_group_enter(group);
+    dispatch_async(queue, ^{
+      [self.audioEngine startIfNecessary];
+      dispatch_group_leave(group);
+    });
+  }
+
+  dispatch_group_wait(group, dispatch_time(DISPATCH_TIME_NOW, 5 * NSEC_PER_SEC));
 }
 
 @end

--- a/apps/fabric-example/ios/FabricExampleTests/AudioPlayerTests.mm
+++ b/apps/fabric-example/ios/FabricExampleTests/AudioPlayerTests.mm
@@ -608,7 +608,7 @@ struct TestAudioOutput {
   XCTAssertEqual(renderedFrameSizes.size(), 3UL);
   XCTAssertEqual(renderedFrameSizes[0], RENDER_QUANTUM_SIZE);
   XCTAssertEqual(renderedFrameSizes[1], RENDER_QUANTUM_SIZE);
-  XCTAssertEqual(renderedFrameSizes[2], 44);
+  XCTAssertEqual(renderedFrameSizes[2], RENDER_QUANTUM_SIZE);
 
   for (int frame = 0; frame < 128; frame += 1) {
     XCTAssertEqualWithAccuracy(output.channels[0][frame], 1.0f, 0.0001f);

--- a/apps/fabric-example/ios/FabricExampleTests/IOSAudioRecorderTests.mm
+++ b/apps/fabric-example/ios/FabricExampleTests/IOSAudioRecorderTests.mm
@@ -33,24 +33,20 @@ class IOSAudioRecorder : public AudioRecorder {
 
   Result<NoneType, std::string> enableFileOutput(
       std::shared_ptr<AudioFileProperties> properties) override;
-  void disableFileOutput() override;
 
   void connect(const std::shared_ptr<RecorderAdapterNode> &node) override;
-  void disconnect() override;
 
   void pause() override;
   void resume() override;
 
   bool isRecording() const override;
   bool isPaused() const override;
-  bool isIdle() const override;
 
   Result<NoneType, std::string> setOnAudioReadyCallback(
       float sampleRate,
       size_t bufferLength,
       int channelCount,
       uint64_t callbackId) override;
-  void clearOnAudioReadyCallback() override;
 
  protected:
   NativeAudioRecorder *nativeRecorder_;

--- a/apps/fabric-example/ios/FabricExampleTests/SystemNotificationManagerTests.mm
+++ b/apps/fabric-example/ios/FabricExampleTests/SystemNotificationManagerTests.mm
@@ -2,6 +2,8 @@
 #import <objc/runtime.h>
 
 #import <audioapi/events/AudioEvent.h>
+#import <audioapi/events/AudioEventPayload.h>
+#import <audioapi/ios/AudioAPIModule.h>
 #import <audioapi/ios/system/AudioEngine.h>
 #import <audioapi/ios/system/AudioSessionManager.h>
 #import <audioapi/ios/system/SystemNotificationManager.h>
@@ -158,7 +160,8 @@
 @property(nonatomic, strong) NSDictionary *lastEventBody;
 
 - (void)resetCapturedEvent;
-- (void)invokeHandlerWithEventName:(audioapi::AudioEvent)eventName eventBody:(NSDictionary *)eventBody;
+- (void)invokeHandlerWithEventName:(audioapi::AudioEvent)eventName
+                           payload:(audioapi::AudioEventPayload)payload;
 
 @end
 
@@ -171,11 +174,33 @@
   self.lastEventBody = nil;
 }
 
-- (void)invokeHandlerWithEventName:(audioapi::AudioEvent)eventName eventBody:(NSDictionary *)eventBody
+- (void)invokeHandlerWithEventName:(audioapi::AudioEvent)eventName
+                           payload:(audioapi::AudioEventPayload)payload
 {
   self.eventInvocationCount += 1;
   self.lastEventNameRaw = static_cast<NSInteger>(eventName);
-  self.lastEventBody = eventBody;
+
+  if (const auto *doublePayload = std::get_if<audioapi::DoubleValuePayload>(&payload)) {
+    self.lastEventBody = @{@"value" : @(doublePayload->value)};
+    return;
+  }
+
+  if (const auto *interruptionPayload = std::get_if<audioapi::InterruptionPayload>(&payload)) {
+    self.lastEventBody = @{
+      @"type" : [NSString stringWithUTF8String:interruptionPayload->type.c_str()],
+      @"shouldResume" : @(interruptionPayload->shouldResume),
+    };
+    return;
+  }
+
+  if (const auto *stringPayload = std::get_if<audioapi::StringPayload>(&payload)) {
+    NSString *key = [NSString stringWithUTF8String:stringPayload->name.c_str()];
+    NSString *value = [NSString stringWithUTF8String:stringPayload->reason.c_str()];
+    self.lastEventBody = @{key : value};
+    return;
+  }
+
+  self.lastEventBody = @{};
 }
 
 @end
@@ -262,6 +287,8 @@ static void ClearFakeSharedAudioSession(void)
 {
   [self.manager stopPollingSecondaryAudioHint];
   [self.manager cleanup];
+  [self.fakeAudioEngine cleanup];
+  [self.fakeSessionManager cleanup];
   self.manager = nil;
   self.module = nil;
   self.fakeAudioEngine = nil;

--- a/packages/react-native-audio-api/android/src/main/cpp/audioapi/android/core/AudioPlayer.cpp
+++ b/packages/react-native-audio-api/android/src/main/cpp/audioapi/android/core/AudioPlayer.cpp
@@ -16,12 +16,14 @@ AudioPlayer::AudioPlayer(
     const std::function<void(std::shared_ptr<DSPAudioBuffer>, int)> &renderAudio,
     float sampleRate,
     int channelCount,
-    std::mutex *driverMutex)
+    std::mutex *driverMutex,
+    const std::shared_ptr<AudioContext> &context)
     : renderAudio_(renderAudio),
       sampleRate_(sampleRate),
       channelCount_(channelCount),
       isRunning_(false),
-      driverMutex_(driverMutex) {}
+      driverMutex_(driverMutex),
+      context_(context) {}
 
 bool AudioPlayer::openAudioStream() {
   AudioStreamBuilder builder;
@@ -129,12 +131,27 @@ AudioPlayer::onAudioReady(AudioStream *oboeStream, void *audioData, int32_t numF
 }
 
 void AudioPlayer::onErrorAfterClose(oboe::AudioStream *stream, oboe::Result error) {
-  if (error == oboe::Result::ErrorDisconnected && driverMutex_ != nullptr) {
-    std::scoped_lock lock(*driverMutex_);
-    cleanup();
-    if (openAudioStream()) {
-      resume();
-    }
+  if (error != oboe::Result::ErrorDisconnected || driverMutex_ == nullptr) {
+    return;
+  }
+
+  // Serialize with start()/resume()/suspend()/close() on the JS / promise-pool threads.
+  std::scoped_lock lock(*driverMutex_);
+
+  auto context = context_.lock();
+  if (context == nullptr || context->isClosed()) {
+    return;
+  }
+
+  // The error thread is detached and can arrive late: if close() or a concurrent
+  // recovery already replaced the stream, don't tear down the healthy new stream.
+  if (stream != mStream_.get()) {
+    return;
+  }
+
+  cleanup();
+  if (openAudioStream()) {
+    resume();
   }
 }
 } // namespace audioapi

--- a/packages/react-native-audio-api/android/src/main/cpp/audioapi/android/core/AudioPlayer.cpp
+++ b/packages/react-native-audio-api/android/src/main/cpp/audioapi/android/core/AudioPlayer.cpp
@@ -8,17 +8,20 @@
 
 #include <algorithm>
 #include <memory>
+#include <mutex>
 
 namespace audioapi {
 
 AudioPlayer::AudioPlayer(
     const std::function<void(std::shared_ptr<DSPAudioBuffer>, int)> &renderAudio,
     float sampleRate,
-    int channelCount)
+    int channelCount,
+    std::mutex *driverMutex)
     : renderAudio_(renderAudio),
       sampleRate_(sampleRate),
       channelCount_(channelCount),
-      isRunning_(false) {}
+      isRunning_(false),
+      driverMutex_(driverMutex) {}
 
 bool AudioPlayer::openAudioStream() {
   AudioStreamBuilder builder;
@@ -42,7 +45,7 @@ bool AudioPlayer::openAudioStream() {
   }
 
   buffer_ = std::make_shared<DSPAudioBuffer>(RENDER_QUANTUM_SIZE, channelCount_, sampleRate_);
-  isInitialized_ = true;
+  isInitialized_.store(true, std::memory_order_release);
   return true;
 }
 
@@ -85,7 +88,7 @@ void AudioPlayer::suspend() {
 }
 
 void AudioPlayer::cleanup() {
-  isInitialized_ = false;
+  isInitialized_.store(false, std::memory_order_release);
 
   if (mStream_ != nullptr) {
     mStream_->close();
@@ -94,13 +97,13 @@ void AudioPlayer::cleanup() {
 }
 
 bool AudioPlayer::isRunning() const {
-  return mStream_ && mStream_->getState() == oboe::StreamState::Started &&
+  return mStream_ != nullptr && mStream_->getState() == oboe::StreamState::Started &&
       isRunning_.load(std::memory_order_acquire);
 }
 
 DataCallbackResult
 AudioPlayer::onAudioReady(AudioStream *oboeStream, void *audioData, int32_t numFrames) {
-  if (!isInitialized_) {
+  if (!isInitialized_.load(std::memory_order_acquire)) {
     return DataCallbackResult::Continue;
   }
 
@@ -126,10 +129,10 @@ AudioPlayer::onAudioReady(AudioStream *oboeStream, void *audioData, int32_t numF
 }
 
 void AudioPlayer::onErrorAfterClose(oboe::AudioStream *stream, oboe::Result error) {
-  if (error == oboe::Result::ErrorDisconnected) {
+  if (error == oboe::Result::ErrorDisconnected && driverMutex_ != nullptr) {
+    std::scoped_lock lock(*driverMutex_);
     cleanup();
     if (openAudioStream()) {
-      isInitialized_ = true;
       resume();
     }
   }

--- a/packages/react-native-audio-api/android/src/main/cpp/audioapi/android/core/AudioPlayer.h
+++ b/packages/react-native-audio-api/android/src/main/cpp/audioapi/android/core/AudioPlayer.h
@@ -24,7 +24,8 @@ class AudioPlayer : public AudioStreamDataCallback,
       const std::function<void(std::shared_ptr<DSPAudioBuffer>, int)> &renderAudio,
       float sampleRate,
       int channelCount,
-      std::mutex *driverMutex);
+      std::mutex *driverMutex,
+      const std::shared_ptr<AudioContext> &context);
 
   ~AudioPlayer() override {
     nativeAudioPlayer_.release();
@@ -42,7 +43,7 @@ class AudioPlayer : public AudioStreamDataCallback,
   DataCallbackResult onAudioReady(AudioStream *oboeStream, void *audioData, int32_t numFrames)
       override;
 
-  void onErrorAfterClose(AudioStream * /* audioStream */, Result /* error */) override;
+  void onErrorAfterClose(AudioStream *audioStream, Result error) override;
 
  private:
   std::function<void(std::shared_ptr<DSPAudioBuffer>, int)> renderAudio_;
@@ -53,6 +54,7 @@ class AudioPlayer : public AudioStreamDataCallback,
   int channelCount_;
   std::atomic<bool> isRunning_;
   std::mutex *driverMutex_;
+  std::weak_ptr<AudioContext> context_;
 
   bool openAudioStream();
 

--- a/packages/react-native-audio-api/android/src/main/cpp/audioapi/android/core/AudioPlayer.h
+++ b/packages/react-native-audio-api/android/src/main/cpp/audioapi/android/core/AudioPlayer.h
@@ -1,9 +1,10 @@
 #pragma once
 
 #include <oboe/Oboe.h>
-#include <cassert>
+#include <atomic>
 #include <functional>
 #include <memory>
+#include <mutex>
 
 #include <audioapi/android/core/NativeAudioPlayer.hpp>
 #include <audioapi/utils/AudioBuffer.hpp>
@@ -22,7 +23,8 @@ class AudioPlayer : public AudioStreamDataCallback,
   AudioPlayer(
       const std::function<void(std::shared_ptr<DSPAudioBuffer>, int)> &renderAudio,
       float sampleRate,
-      int channelCount);
+      int channelCount,
+      std::mutex *driverMutex);
 
   ~AudioPlayer() override {
     nativeAudioPlayer_.release();
@@ -46,10 +48,11 @@ class AudioPlayer : public AudioStreamDataCallback,
   std::function<void(std::shared_ptr<DSPAudioBuffer>, int)> renderAudio_;
   std::shared_ptr<AudioStream> mStream_;
   std::shared_ptr<DSPAudioBuffer> buffer_;
-  bool isInitialized_ = false;
+  std::atomic<bool> isInitialized_{false};
   float sampleRate_;
   int channelCount_;
   std::atomic<bool> isRunning_;
+  std::mutex *driverMutex_;
 
   bool openAudioStream();
 

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/AudioContext.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/AudioContext.cpp
@@ -28,7 +28,7 @@ void AudioContext::initialize() {
   BaseAudioContext::initialize();
 #ifdef ANDROID
   audioPlayer_ = std::make_shared<AudioPlayer>(
-      this->renderAudio(), getSampleRate(), destination_->getChannelCount());
+      this->renderAudio(), getSampleRate(), destination_->getChannelCount(), &driverMutex_);
   audioPlayer_->openAudioStream();
 #else
   audioPlayer_ = std::make_shared<IOSAudioPlayer>(
@@ -36,7 +36,26 @@ void AudioContext::initialize() {
 #endif
 }
 
+bool AudioContext::tryStartDriver() {
+  if (getState() == ContextState::CLOSED) {
+    return false;
+  }
+
+  if (isInitialized_.load(std::memory_order_acquire)) {
+    return false;
+  }
+
+  if (audioPlayer_->start()) {
+    isInitialized_.store(true, std::memory_order_release);
+    setState(ContextState::RUNNING);
+    return true;
+  }
+
+  return false;
+}
+
 void AudioContext::close() {
+  std::scoped_lock lock(driverMutex_);
   setState(ContextState::CLOSED);
 
   audioPlayer_->stop();
@@ -45,6 +64,8 @@ void AudioContext::close() {
 }
 
 bool AudioContext::resume() {
+  std::scoped_lock lock(driverMutex_);
+
   if (getState() == ContextState::CLOSED) {
     return false;
   }
@@ -58,10 +79,12 @@ bool AudioContext::resume() {
     return true;
   }
 
-  return start();
+  return tryStartDriver();
 }
 
 bool AudioContext::suspend() {
+  std::scoped_lock lock(driverMutex_);
+
   if (getState() == ContextState::CLOSED) {
     return false;
   }
@@ -77,18 +100,8 @@ bool AudioContext::suspend() {
 }
 
 bool AudioContext::start() {
-  if (getState() == ContextState::CLOSED) {
-    return false;
-  }
-
-  if (!isInitialized_.load(std::memory_order_acquire) && audioPlayer_->start()) {
-    isInitialized_.store(true, std::memory_order_release);
-    setState(ContextState::RUNNING);
-
-    return true;
-  }
-
-  return false;
+  std::scoped_lock lock(driverMutex_);
+  return tryStartDriver();
 }
 
 std::function<void(std::shared_ptr<DSPAudioBuffer>, int)> AudioContext::renderAudio() {

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/AudioContext.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/AudioContext.cpp
@@ -28,7 +28,11 @@ void AudioContext::initialize() {
   BaseAudioContext::initialize();
 #ifdef ANDROID
   audioPlayer_ = std::make_shared<AudioPlayer>(
-      this->renderAudio(), getSampleRate(), destination_->getChannelCount(), &driverMutex_);
+      this->renderAudio(),
+      getSampleRate(),
+      destination_->getChannelCount(),
+      &driverMutex_,
+      std::static_pointer_cast<AudioContext>(shared_from_this()));
   audioPlayer_->openAudioStream();
 #else
   audioPlayer_ = std::make_shared<IOSAudioPlayer>(

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/AudioContext.h
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/AudioContext.h
@@ -7,6 +7,7 @@
 
 #include <functional>
 #include <memory>
+#include <mutex>
 
 namespace audioapi {
 #ifdef ANDROID
@@ -24,12 +25,18 @@ class AudioContext : public BaseAudioContext {
   ~AudioContext() override;
   DELETE_COPY_AND_MOVE(AudioContext);
 
+  /// Promise thread pool (`AudioContextHostObject::close`).
   void close();
+  /// Promise thread pool (`AudioContextHostObject::resume`). Races with `start()`.
   bool resume();
+  /// Promise thread pool (`AudioContextHostObject::suspend`). Races with `start()`.
   bool suspend();
+  /// JS thread (`AudioScheduledSourceNode::start`). Races with `resume` / `suspend` / `close`.
   bool start();
+  /// JS thread only — runs synchronously in `BaseAudioContextHostObject` construction.
   void initialize() override;
 
+  /// JS thread only — synchronous HostObject call; graph mutation only.
   std::shared_ptr<MediaElementAudioSourceNode> createMediaElementSource(
       const std::shared_ptr<AudioFileSourceNode> &fileSource);
 
@@ -39,11 +46,17 @@ class AudioContext : public BaseAudioContext {
 #else
   std::shared_ptr<IOSAudioPlayer> audioPlayer_;
 #endif
+  /// Serializes `start` / `resume` / `suspend` / `close` across JS and promise-pool threads.
+  mutable std::mutex driverMutex_;
   std::atomic<bool> isInitialized_{false};
 
+  /// JS thread only — read from `getState()`; must not acquire `driverMutex_`.
   bool isDriverRunning() const override;
 
   std::function<void(std::shared_ptr<DSPAudioBuffer>, int)> renderAudio();
+
+  /// Caller must hold `driverMutex_`.
+  bool tryStartDriver();
 };
 
 } // namespace audioapi

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/AudioContext.h
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/AudioContext.h
@@ -25,18 +25,14 @@ class AudioContext : public BaseAudioContext {
   ~AudioContext() override;
   DELETE_COPY_AND_MOVE(AudioContext);
 
-  /// Promise thread pool (`AudioContextHostObject::close`).
   void close();
-  /// Promise thread pool (`AudioContextHostObject::resume`). Races with `start()`.
   bool resume();
-  /// Promise thread pool (`AudioContextHostObject::suspend`). Races with `start()`.
   bool suspend();
-  /// JS thread (`AudioScheduledSourceNode::start`). Races with `resume` / `suspend` / `close`.
   bool start();
+
   /// JS thread only — runs synchronously in `BaseAudioContextHostObject` construction.
   void initialize() override;
 
-  /// JS thread only — synchronous HostObject call; graph mutation only.
   std::shared_ptr<MediaElementAudioSourceNode> createMediaElementSource(
       const std::shared_ptr<AudioFileSourceNode> &fileSource);
 
@@ -50,7 +46,6 @@ class AudioContext : public BaseAudioContext {
   mutable std::mutex driverMutex_;
   std::atomic<bool> isInitialized_{false};
 
-  /// JS thread only — read from `getState()`; must not acquire `driverMutex_`.
   bool isDriverRunning() const override;
 
   std::function<void(std::shared_ptr<DSPAudioBuffer>, int)> renderAudio();

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/BaseAudioContext.h
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/BaseAudioContext.h
@@ -68,6 +68,9 @@ class BaseAudioContext : public std::enable_shared_from_this<BaseAudioContext> {
   virtual ~BaseAudioContext() = default;
 
   ContextState getState();
+  [[nodiscard]] bool isClosed() const {
+    return state_.load(std::memory_order_acquire) == ContextState::CLOSED;
+  }
   [[nodiscard]] float getSampleRate() const;
   [[nodiscard]] double getCurrentTime() const;
   [[nodiscard]] std::size_t getCurrentSampleFrame() const;

--- a/packages/react-native-audio-api/ios/audioapi/ios/system/AudioEngine.h
+++ b/packages/react-native-audio-api/ios/audioapi/ios/system/AudioEngine.h
@@ -40,6 +40,7 @@ typedef NS_ENUM(NSInteger, AudioEngineState) {
 - (void)onInterruptionBegin;
 - (void)onInterruptionEnd:(bool)shouldResume;
 - (void)onSessionDeactivated;
+- (void)markSessionDeactivationInvalidatedGraph;
 
 - (AudioEngineState)getState;
 - (bool)isEngineRunning;

--- a/packages/react-native-audio-api/ios/audioapi/ios/system/AudioEngine.mm
+++ b/packages/react-native-audio-api/ios/audioapi/ios/system/AudioEngine.mm
@@ -1,6 +1,8 @@
 #import <audioapi/ios/system/AudioEngine.h>
 #import <audioapi/ios/system/AudioSessionManager.h>
 
+#include <mutex>
+
 @interface AudioEngineSourceRegistration : NSObject
 
 @property (nonatomic, copy) AVAudioSourceNodeRenderBlock renderBlock;
@@ -21,7 +23,9 @@
 @implementation AudioEngineInputRegistration
 @end
 
-@interface AudioEngine ()
+@interface AudioEngine () {
+  std::mutex _engineLock;
+}
 
 @property (nonatomic, strong)
     NSMutableDictionary<NSString *, AudioEngineSourceRegistration *> *sourceRegistrations;
@@ -34,6 +38,10 @@
 - (void)materializeSourceNodeWithId:(NSString *)sourceNodeId;
 - (BOOL)materializeInputNodeIfNeeded;
 - (void)materializeTrackedNodesIfNeeded;
+
+- (AVAudioFormat *)liveInputFormat;
+- (void)resetInputNode;
+- (void)rebuildAudioEngineAndResumeIfNeeded;
 
 @end
 
@@ -112,6 +120,7 @@ static AudioEngine *_sharedInstance = nil;
 
 - (void)cleanup
 {
+  std::scoped_lock lock(_engineLock);
   [self destroyAudioEngine];
   self.state = AudioEngineState::AudioEngineStateIdle;
   self.sourceRegistrations = nil;
@@ -124,6 +133,10 @@ static AudioEngine *_sharedInstance = nil;
 
   [self.sessionManager setActive:false error:nil];
   self.sessionManager = nil;
+
+  if (_sharedInstance == self) {
+    _sharedInstance = nil;
+  }
 }
 
 - (void)materializeSourceNodeWithId:(NSString *)sourceNodeId
@@ -149,7 +162,7 @@ static AudioEngine *_sharedInstance = nil;
 
 - (AVAudioFormat *)currentInputConnectionFormat
 {
-  AVAudioFormat *inputFormat = [self getLiveInputFormat];
+  AVAudioFormat *inputFormat = [self liveInputFormat];
 
   if (inputFormat == nil || inputFormat.sampleRate <= 0 || inputFormat.channelCount == 0) {
     return nil;
@@ -200,6 +213,7 @@ static AudioEngine *_sharedInstance = nil;
                                    sampleRate:(float)sampleRate
                                  channelCount:(AVAudioChannelCount)channelCount
 {
+  std::scoped_lock lock(_engineLock);
   [self createAudioEngineIfNeeded];
 
   NSString *sourceNodeId = [[NSUUID UUID] UUIDString];
@@ -216,6 +230,7 @@ static AudioEngine *_sharedInstance = nil;
 
 - (void)detachSourceNodeWithId:(NSString *)sourceNodeId
 {
+  std::scoped_lock lock(_engineLock);
   AVAudioSourceNode *sourceNode = self.sourceNodes[sourceNodeId];
 
   if (self.sourceRegistrations[sourceNodeId] == nil) {
@@ -238,10 +253,11 @@ static AudioEngine *_sharedInstance = nil;
 
 - (void)attachInputNodeWithReceiverBlock:(AVAudioSinkNodeReceiverBlock)receiverBlock
 {
+  std::scoped_lock lock(_engineLock);
   [self createAudioEngineIfNeeded];
 
   if (self.inputRegistration != nil || self.inputNode != nil) {
-    [self detachInputNode];
+    [self resetInputNode];
   }
 
   AudioEngineInputRegistration *registration = [[AudioEngineInputRegistration alloc] init];
@@ -251,7 +267,7 @@ static AudioEngine *_sharedInstance = nil;
   [self materializeInputNodeIfNeeded];
 }
 
-- (void)detachInputNode
+- (void)resetInputNode
 {
   if (self.inputRegistration == nil && self.inputNode == nil) {
     return;
@@ -269,7 +285,13 @@ static AudioEngine *_sharedInstance = nil;
   }
 }
 
-- (AVAudioFormat *)getLiveInputFormat
+- (void)detachInputNode
+{
+  std::scoped_lock lock(_engineLock);
+  [self resetInputNode];
+}
+
+- (AVAudioFormat *)liveInputFormat
 {
   if (self.audioEngine == nil) {
     return nil;
@@ -290,8 +312,15 @@ static AudioEngine *_sharedInstance = nil;
   return inputFormat;
 }
 
+- (AVAudioFormat *)getLiveInputFormat
+{
+  std::scoped_lock lock(_engineLock);
+  return [self liveInputFormat];
+}
+
 - (void)onInterruptionBegin
 {
+  std::scoped_lock lock(_engineLock);
   if (self.state != AudioEngineState::AudioEngineStateRunning) {
     return;
   }
@@ -301,6 +330,7 @@ static AudioEngine *_sharedInstance = nil;
 
 - (void)onSessionDeactivated
 {
+  std::scoped_lock lock(_engineLock);
   BOOL hadTrackedGraph = [self hasTrackedGraph];
   BOOL hadActiveState = self.state != AudioEngineState::AudioEngineStateIdle;
 
@@ -326,15 +356,22 @@ static AudioEngine *_sharedInstance = nil;
   self.state = AudioEngineState::AudioEngineStatePaused;
 }
 
+- (void)markSessionDeactivationInvalidatedGraph
+{
+  std::scoped_lock lock(_engineLock);
+  self.sessionDeactivationInvalidatedGraph = YES;
+}
+
 - (void)onInterruptionEnd:(bool)shouldResume
 {
+  std::scoped_lock lock(_engineLock);
   NSError *error = nil;
 
   if (self.state != AudioEngineState::AudioEngineStateInterrupted) {
     return;
   }
 
-  [self stopIfNecessary];
+  [self stopEngine];
   [self rebuildAudioEngine];
 
   if (!shouldResume) {
@@ -359,12 +396,27 @@ static AudioEngine *_sharedInstance = nil;
 
 - (AudioEngineState)getState
 {
+  std::scoped_lock lock(_engineLock);
   return self.state;
 }
 
 - (bool)isEngineRunning
 {
+  std::scoped_lock lock(_engineLock);
   return self.audioEngine != nil && [self.audioEngine isRunning];
+}
+
+- (void)rebuildAudioEngineAndResumeIfNeeded
+{
+  if ([self.audioEngine isRunning]) {
+    [self.audioEngine stop];
+  }
+
+  [self rebuildAudioEngine];
+
+  if (self.state == AudioEngineState::AudioEngineStateRunning) {
+    [self startEngine];
+  }
 }
 
 - (void)rebuildAudioEngine
@@ -380,7 +432,8 @@ static AudioEngine *_sharedInstance = nil;
 {
   NSError *error = nil;
 
-  if ([self isEngineRunning] && self.state == AudioEngineState::AudioEngineStateRunning) {
+  if (self.audioEngine != nil && [self.audioEngine isRunning] &&
+      self.state == AudioEngineState::AudioEngineStateRunning) {
     return true;
   }
 
@@ -393,7 +446,7 @@ static AudioEngine *_sharedInstance = nil;
 
   if (self.state == AudioEngineState::AudioEngineStateInterrupted || self.graphNeedsRebuild ||
       self.sessionDeactivationInvalidatedGraph) {
-    [self restartAudioEngine];
+    [self rebuildAudioEngineAndResumeIfNeeded];
   } else {
     [self materializeTrackedNodesIfNeeded];
   }
@@ -431,7 +484,9 @@ static AudioEngine *_sharedInstance = nil;
 
 - (bool)startIfNecessary
 {
-  if (self.state == AudioEngineState::AudioEngineStateRunning && [self isEngineRunning]) {
+  std::scoped_lock lock(_engineLock);
+  if (self.state == AudioEngineState::AudioEngineStateRunning && self.audioEngine != nil &&
+      [self.audioEngine isRunning]) {
     return true;
   }
 
@@ -444,6 +499,7 @@ static AudioEngine *_sharedInstance = nil;
 
 - (void)pauseIfNecessary
 {
+  std::scoped_lock lock(_engineLock);
   if (self.state == AudioEngineState::AudioEngineStatePaused) {
     return;
   }
@@ -457,15 +513,13 @@ static AudioEngine *_sharedInstance = nil;
 
 - (void)stopIfNecessary
 {
-  if (self.state == AudioEngineState::AudioEngineStateIdle) {
-    return;
-  }
-
+  std::scoped_lock lock(_engineLock);
   [self stopEngine];
 }
 
 - (void)stopIfPossible
 {
+  std::scoped_lock lock(_engineLock);
   BOOL hasInput = self.inputRegistration != nil;
   BOOL hasSources = [self.sourceRegistrations count] > 0;
 
@@ -480,18 +534,13 @@ static AudioEngine *_sharedInstance = nil;
 
 - (void)restartAudioEngine
 {
-  if ([self.audioEngine isRunning]) {
-    [self.audioEngine stop];
-  }
-
-  [self rebuildAudioEngine];
-  if (self.state == AudioEngineState::AudioEngineStateRunning) {
-    [self startEngine];
-  }
+  std::scoped_lock lock(_engineLock);
+  [self rebuildAudioEngineAndResumeIfNeeded];
 }
 
 - (void)logAudioEngineState
 {
+  std::scoped_lock lock(_engineLock);
   AVAudioSession *session = [AVAudioSession sharedInstance];
 
   NSLog(@"================ 🎧 AVAudioEngine STATE ================");

--- a/packages/react-native-audio-api/ios/audioapi/ios/system/AudioSessionManager.mm
+++ b/packages/react-native-audio-api/ios/audioapi/ios/system/AudioSessionManager.mm
@@ -123,7 +123,7 @@ static AudioSessionManager *_sharedInstance = nil;
 
   if (configChanged) {
     AudioEngine *audioEngine = [AudioEngine sharedInstance];
-    audioEngine.sessionDeactivationInvalidatedGraph = YES;
+    [audioEngine markSessionDeactivationInvalidatedGraph];
   }
 
   self.desiredCategory = category;


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## ⚠️ Breaking changes ⚠️

<!-- A brief description of the breaking changes -->

-

## Introduced changes

<!-- A brief description of the changes -->

- this pr aims to eliminate race condition in the audio native engines. For example one can happen when `audiocontext.resume()` and `node.start()` are called. Resume runs on separate thread pool which handles promises and starting node is done synchronously on js thread. Both of them would try to call inside them functions of engine, which is obvious race condition between two threads.

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added/Conducted relevant tests
- [ ] Performed self-review of the code
- [ ] Updated Web Audio API coverage
- [ ] Added support for web
- [ ] Updated old arch android spec file
