### PR TITLE
fix: removed race conditions connected to promises thread pool

### DIFF
--- a/.claude/skills/thread-safety-itc/SKILL.md
+++ b/.claude/skills/thread-safety-itc/SKILL.md
@@ -142,12 +142,14 @@ Control-plane synchronization uses two layers — both are non-recursive `std::m
 
 | Layer | Location | Protects |
 |---|---|---|
-| Context | `AudioContext::driverMutex_` (iOS + Android) | `start` / `resume` / `suspend` / `close` only — JS-thread `source.start()` vs promise-pool `resume()` / `suspend()` / `close()` |
+| Context | `BaseAudioContext::driverMutex_` (`AudioContext` + `OfflineAudioContext`) | `start` / `resume` / `suspend` / `close` (live); `resume` / `suspend` / `startRendering` (offline) — JS thread vs promise-pool |
 | Engine | `AudioEngine` mutex (iOS only) | Process-wide `AVAudioEngine` graph: attach/detach, engine start/stop, interruptions, recorder paths |
 
 `AudioContext::initialize()`, `createMediaElementSource()`, and `isDriverRunning()` are JS-thread-only — do not take `driverMutex_`. `getState()` reads atomics and `isDriverRunning()` lock-free; do not acquire `driverMutex_` from there.
 
 On Android, `AudioPlayer::onErrorAfterClose` also takes `driverMutex_` because Oboe error callbacks bypass `AudioContext`.
+
+**Live `AudioContext` render quiescence:** `currentRenders_` on `AudioContext` is incremented at the start of each platform I/O callback (`IOSAudioPlayer::deliverOutputBuffers` / `AudioPlayer::onAudioReady`) via a reference passed in `initialize()`, and decremented when the callback returns (RAII scope). `suspend()` and `close()` call `waitForRenderQuiescence()` (under `driverMutex_`) before `processAudioEvents()` / `cleanup()`.
 
 ---
 
@@ -159,9 +161,9 @@ On Android, `AudioPlayer::onErrorAfterClose` also takes `driverMutex_` because O
 - **`std::vector::push_back` in `processNode()`** → may allocate; preallocate in constructor.
 - **`std::mutex` anywhere in `processNode()`** → deadlock risk and real-time violation.
 - **Copying `shared_ptr` inside `processNode()`** — increments atomic refcount; capture before entering hot path.
-- **Locking `initialize()` or graph factory methods** — `initialize()` runs synchronously during HostObject construction on the JS thread; node factories and `createMediaElementSource()` are synchronous JS calls. Only `start` / `resume` / `suspend` / `close` need `driverMutex_`.
-- **Locking only `AudioContext`** — iOS recorder, session, and interruption paths mutate the shared `AVAudioEngine` outside `AudioContext`; keep the `AudioEngine` mutex on those entry points.
-- **Re-entering `driverMutex_` or the `AudioEngine` mutex on the same thread** — call `tryStartDriver()` directly from `resume()` instead of `start()`; use lock-free `isStreamRunning()` from `isDriverRunning()`.
+- **Locking `initialize()` or graph factory methods** — `initialize()` runs synchronously during HostObject construction on the JS thread; node factories and `createMediaElementSource()` are synchronous JS calls. Only lifecycle methods that touch the driver or offline render thread need `driverMutex_`.
+- **Locking only `AudioContext`** — iOS recorder, session, and interruption paths mutate the shared `AVAudioEngine` outside `AudioContext`; keep the `AudioEngine` mutex on those entry points. Offline render uses the same `driverMutex_` on `BaseAudioContext`.
+- **Re-entering `driverMutex_` or the `AudioEngine` mutex on the same thread** — call `tryStartDriver()` directly from `resume()` instead of `start()`; use lock-free `isStreamRunning()` from `isDriverRunning()`. `AudioContext::start()` does not acquire `driverMutex_`; it asserts the lock is already held when the driver is not initialized (via `scheduleAudioEvent` synchronous path). When already initialized, `start()` is a lock-free no-op so `source.start()` on the audio thread does not take the mutex.
 
 ---
 

--- a/apps/common-app/src/demos/Record/PlaybackVisualization.tsx
+++ b/apps/common-app/src/demos/Record/PlaybackVisualization.tsx
@@ -64,7 +64,7 @@ const PlaybackVisualization: React.FC<PlaybackVisualizationProps> = (props) => {
   }, [buffer, size.height, size.width]);
 
   const bgPath = useMemo(() => {
-    const path = Skia.Path.Make();
+    const path = Skia.PathBuilder.Make().build();
 
     bufferWaveform.forEach((bar) => {
       path.moveTo(bar.x, bar.y);
@@ -76,7 +76,7 @@ const PlaybackVisualization: React.FC<PlaybackVisualizationProps> = (props) => {
   }, [bufferWaveform]);
 
   const progressPath = useDerivedValue(() => {
-    const path = Skia.Path.Make();
+    const path = Skia.PathBuilder.Make().build();
 
     const totalBars = bufferWaveform.length;
     const currentBar = Math.floor(

--- a/apps/common-app/src/demos/Record/RecordingVisualization.tsx
+++ b/apps/common-app/src/demos/Record/RecordingVisualization.tsx
@@ -163,7 +163,7 @@ const RecordingVisualization: React.FC<RecordingVisualizationProps> = ({
   }, [size.width]);
 
   const waveformPath = useDerivedValue(() => {
-    const path = Skia.Path.Make();
+    const path = Skia.PathBuilder.Make().build();
     const currentHeights = barHeights.value;
     const canvasHeight = size.height;
 
@@ -190,7 +190,7 @@ const RecordingVisualization: React.FC<RecordingVisualizationProps> = ({
   }, [size, numBars]);
 
   const historyWaveformPath = useDerivedValue(() => {
-    const path = Skia.Path.Make();
+    const path = Skia.PathBuilder.Make().build();
     const canvasHeight = lifetimeSize.height;
     const values = historyRenderer.value;
 

--- a/apps/common-app/src/examples/AudioVisualizer/Charts.tsx
+++ b/apps/common-app/src/examples/AudioVisualizer/Charts.tsx
@@ -22,7 +22,7 @@ function buildTimePath(
   fftSize: number,
   layout: ReturnType<typeof getVisualizerLayout>
 ) {
-  const path = Skia.Path.Make();
+  const path = Skia.PathBuilder.Make().build();
   const { cx, cy, innerRadius } = layout;
   const span = innerRadius * 2;
   const startX = cx - innerRadius;
@@ -46,7 +46,7 @@ function buildFrequencyPath(
   frequencyBinCount: number,
   layout: ReturnType<typeof getVisualizerLayout>
 ) {
-  const path = Skia.Path.Make();
+  const path = Skia.PathBuilder.Make().build();
   const { cx, cy, outerRadius } = layout;
   const maxSteps = 2 * (frequencyBinCount - 64);
 

--- a/apps/common-app/src/examples/DrumMachine/PatternShape.tsx
+++ b/apps/common-app/src/examples/DrumMachine/PatternShape.tsx
@@ -43,7 +43,7 @@ const PatternShape: React.FC<PatternShapeProps> = (props) => {
 
     pathPoints.push(pathPoints[0]);
 
-    const skPath = Skia.Path.Make();
+    const skPath = Skia.PathBuilder.Make().build();
 
     skPath.moveTo(pathPoints[0].x, pathPoints[0].y);
 

--- a/packages/react-native-audio-api/android/src/main/cpp/audioapi/android/core/AudioPlayer.cpp
+++ b/packages/react-native-audio-api/android/src/main/cpp/audioapi/android/core/AudioPlayer.cpp
@@ -2,6 +2,7 @@
 #include <audioapi/android/core/AudioPlayer.h>
 #include <audioapi/core/AudioContext.h>
 #include <audioapi/core/utils/Constants.h>
+#include <audioapi/core/utils/CurrentRenderScope.h>
 #include <audioapi/utils/AudioArray.hpp>
 
 #include <jni.h>
@@ -17,8 +18,10 @@ AudioPlayer::AudioPlayer(
     float sampleRate,
     int channelCount,
     std::mutex *driverMutex,
-    const std::shared_ptr<AudioContext> &context)
+    const std::shared_ptr<AudioContext> &context,
+    std::atomic<uint32_t> &currentRenders)
     : renderAudio_(renderAudio),
+      currentRenders_(currentRenders),
       sampleRate_(sampleRate),
       channelCount_(channelCount),
       isRunning_(false),
@@ -108,6 +111,8 @@ AudioPlayer::onAudioReady(AudioStream *oboeStream, void *audioData, int32_t numF
   if (!isInitialized_.load(std::memory_order_acquire)) {
     return DataCallbackResult::Continue;
   }
+
+  const CurrentRenderScope renderScope(currentRenders_);
 
   auto *buffer = static_cast<float *>(audioData);
   int processedFrames = 0;

--- a/packages/react-native-audio-api/android/src/main/cpp/audioapi/android/core/AudioPlayer.h
+++ b/packages/react-native-audio-api/android/src/main/cpp/audioapi/android/core/AudioPlayer.h
@@ -25,7 +25,8 @@ class AudioPlayer : public AudioStreamDataCallback,
       float sampleRate,
       int channelCount,
       std::mutex *driverMutex,
-      const std::shared_ptr<AudioContext> &context);
+      const std::shared_ptr<AudioContext> &context,
+      std::atomic<uint32_t> &currentRenders);
 
   ~AudioPlayer() override {
     nativeAudioPlayer_.release();
@@ -47,6 +48,7 @@ class AudioPlayer : public AudioStreamDataCallback,
 
  private:
   std::function<void(std::shared_ptr<DSPAudioBuffer>, int)> renderAudio_;
+  std::atomic<uint32_t> &currentRenders_;
   std::shared_ptr<AudioStream> mStream_;
   std::shared_ptr<DSPAudioBuffer> buffer_;
   std::atomic<bool> isInitialized_{false};

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/AudioContext.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/AudioContext.cpp
@@ -9,6 +9,7 @@
 #include <audioapi/core/sources/MediaElementAudioSourceNode.h>
 #include <audioapi/core/utils/AudioGraphManager.h>
 #include <memory>
+#include <thread>
 
 namespace audioapi {
 AudioContext::AudioContext(
@@ -32,15 +33,18 @@ void AudioContext::initialize() {
       getSampleRate(),
       destination_->getChannelCount(),
       &driverMutex_,
-      std::static_pointer_cast<AudioContext>(shared_from_this()));
+      std::static_pointer_cast<AudioContext>(shared_from_this()),
+      currentRenders_);
   audioPlayer_->openAudioStream();
 #else
   audioPlayer_ = std::make_shared<IOSAudioPlayer>(
-      this->renderAudio(), getSampleRate(), destination_->getChannelCount());
+      this->renderAudio(), getSampleRate(), destination_->getChannelCount(), currentRenders_);
 #endif
 }
 
 bool AudioContext::tryStartDriver() {
+  assertDriverMutexHeld();
+
   if (getState() == ContextState::CLOSED) {
     return false;
   }
@@ -63,6 +67,8 @@ void AudioContext::close() {
   setState(ContextState::CLOSED);
 
   audioPlayer_->stop();
+  waitForRenderQuiescence();
+  processAudioEvents();
   audioPlayer_->cleanup();
   getGraphManager()->cleanup();
 }
@@ -98,14 +104,26 @@ bool AudioContext::suspend() {
   }
 
   audioPlayer_->suspend();
-
+  waitForRenderQuiescence();
+  processAudioEvents();
   setState(ContextState::SUSPENDED);
   return true;
 }
 
 bool AudioContext::start() {
-  std::scoped_lock lock(driverMutex_);
+  if (isInitialized_.load(std::memory_order_acquire)) {
+    return false;
+  }
+
+  assertDriverMutexHeld();
   return tryStartDriver();
+}
+
+void AudioContext::waitForRenderQuiescence() const {
+  assertDriverMutexHeld();
+  while (currentRenders_.load(std::memory_order_acquire) != 0) {
+    std::this_thread::yield();
+  }
 }
 
 std::function<void(std::shared_ptr<DSPAudioBuffer>, int)> AudioContext::renderAudio() {

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/AudioContext.h
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/AudioContext.h
@@ -5,9 +5,9 @@
 #include <audioapi/utils/AudioBuffer.hpp>
 #include <audioapi/utils/Macros.h>
 
+#include <atomic>
 #include <functional>
 #include <memory>
-#include <mutex>
 
 namespace audioapi {
 #ifdef ANDROID
@@ -42,9 +42,10 @@ class AudioContext : public BaseAudioContext {
 #else
   std::shared_ptr<IOSAudioPlayer> audioPlayer_;
 #endif
-  /// Serializes `start` / `resume` / `suspend` / `close` across JS and promise-pool threads.
-  mutable std::mutex driverMutex_;
   std::atomic<bool> isInitialized_{false};
+  /// Audio I/O callback thread increments around each platform render callback;
+  /// control thread waits on suspend/close.
+  std::atomic<uint32_t> currentRenders_{0};
 
   bool isDriverRunning() const override;
 
@@ -52,6 +53,9 @@ class AudioContext : public BaseAudioContext {
 
   /// Caller must hold `driverMutex_`.
   bool tryStartDriver();
+
+  /// Blocks until no audio I/O callback is in flight. Caller must hold `driverMutex_`.
+  void waitForRenderQuiescence() const;
 };
 
 } // namespace audioapi

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/BaseAudioContext.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/BaseAudioContext.cpp
@@ -48,7 +48,7 @@ void BaseAudioContext::initialize() {
   destination_ = std::make_shared<AudioDestinationNode>(shared_from_this());
 }
 
-ContextState BaseAudioContext::getState() {
+ContextState BaseAudioContext::getState() const {
   auto state = state_.load(std::memory_order_acquire);
 
   if (state == ContextState::CLOSED || isDriverRunning()) {

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/BaseAudioContext.h
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/BaseAudioContext.h
@@ -12,6 +12,7 @@
 #include <complex>
 #include <cstddef>
 #include <memory>
+#include <mutex>
 #include <utility>
 #include <vector>
 
@@ -67,7 +68,7 @@ class BaseAudioContext : public std::enable_shared_from_this<BaseAudioContext> {
       const RuntimeRegistry &runtimeRegistry);
   virtual ~BaseAudioContext() = default;
 
-  ContextState getState();
+  ContextState getState() const;
   [[nodiscard]] bool isClosed() const {
     return state_.load(std::memory_order_acquire) == ContextState::CLOSED;
   }
@@ -128,8 +129,8 @@ class BaseAudioContext : public std::enable_shared_from_this<BaseAudioContext> {
 
   template <typename F>
   bool scheduleAudioEvent(F &&event) noexcept { // NOLINT(cppcoreguidelines-missing-std-forward)
-    if (getState() != ContextState::RUNNING) {
-      processAudioEvents();
+    std::scoped_lock lock(driverMutex_);
+    if (!isDriverRunning()) {
       event(*this);
       return true;
     }
@@ -141,8 +142,22 @@ class BaseAudioContext : public std::enable_shared_from_this<BaseAudioContext> {
   std::shared_ptr<AudioDestinationNode> destination_;
   std::shared_ptr<AudioGraphManager> graphManager_;
 
- private:
+  /// Serializes context lifecycle and driver control across the JS thread and the
+  /// promise-vendor thread pool (`resume` / `suspend` / `close` / offline render).
+  mutable std::mutex driverMutex_;
   std::atomic<ContextState> state_;
+
+  /// Debug-only: `driverMutex_` must already be held by the calling thread.
+  void assertDriverMutexHeld() const {
+#ifndef NDEBUG
+    if (driverMutex_.try_lock()) {
+      driverMutex_.unlock();
+      assert(false && "driverMutex_ must be held by the current thread");
+    }
+#endif
+  }
+
+ private:
   std::atomic<float> sampleRate_;
   std::shared_ptr<IAudioEventHandlerRegistry> audioEventHandlerRegistry_;
   RuntimeRegistry runtimeRegistry_;

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/OfflineAudioContext.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/OfflineAudioContext.cpp
@@ -7,6 +7,7 @@
 #include <audioapi/core/utils/Locker.h>
 #include <audioapi/utils/AudioArray.hpp>
 
+#include <audioapi/core/types/ContextState.h>
 #include <algorithm>
 #include <cassert>
 #include <memory>
@@ -33,7 +34,7 @@ OfflineAudioContext::~OfflineAudioContext() {
 }
 
 void OfflineAudioContext::resume() {
-  Locker locker(mutex_);
+  std::scoped_lock lock(driverMutex_);
 
   if (getState() == ContextState::RUNNING) {
     return;
@@ -43,7 +44,7 @@ void OfflineAudioContext::resume() {
 }
 
 void OfflineAudioContext::suspend(double when, const std::function<void()> &callback) {
-  Locker locker(mutex_);
+  std::scoped_lock lock(driverMutex_);
 
   // we can only suspend once per render quantum at the end of the quantum
   // first quantum is [0, RENDER_QUANTUM_SIZE)
@@ -64,7 +65,7 @@ void OfflineAudioContext::renderAudio() {
 
   std::thread([this]() {
     while (currentSampleFrame_ < length_) {
-      Locker locker(mutex_);
+      Locker locker(driverMutex_);
       int framesToProcess =
           std::min(static_cast<int>(length_ - currentSampleFrame_), RENDER_QUANTUM_SIZE);
 
@@ -82,6 +83,8 @@ void OfflineAudioContext::renderAudio() {
         auto callback = suspend->second;
         scheduledSuspends_.erase(currentSampleFrame_);
         setState(ContextState::SUSPENDED);
+        processAudioEvents();
+        locker.unlock();
         callback();
         return;
       }
@@ -89,18 +92,19 @@ void OfflineAudioContext::renderAudio() {
 
     // Rendering completed
     resultCallback_(resultBuffer_);
+    setState(ContextState::CLOSED);
   }).detach();
 }
 
 void OfflineAudioContext::startRendering(OfflineAudioContextResultCallback callback) {
-  Locker locker(mutex_);
+  std::scoped_lock lock(driverMutex_);
 
   resultCallback_ = std::move(callback);
   renderAudio();
 }
 
 bool OfflineAudioContext::isDriverRunning() const {
-  return true;
+  return state_.load(std::memory_order_acquire) == ContextState::RUNNING;
 }
 
 } // namespace audioapi

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/OfflineAudioContext.h
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/OfflineAudioContext.h
@@ -6,7 +6,6 @@
 #include <audioapi/utils/Macros.h>
 
 #include <memory>
-#include <mutex>
 #include <unordered_map>
 
 namespace audioapi {
@@ -25,18 +24,11 @@ class OfflineAudioContext : public BaseAudioContext {
   ~OfflineAudioContext() override;
   DELETE_COPY_AND_MOVE(OfflineAudioContext);
 
-  /// @note JS Thread only
   void resume();
-
-  /// @note JS Thread only
   void suspend(double when, const OfflineAudioContextSuspendCallback &callback);
-
-  /// @note JS Thread only
   void startRendering(OfflineAudioContextResultCallback callback);
 
  private:
-  std::mutex mutex_;
-
   std::unordered_map<size_t, OfflineAudioContextSuspendCallback> scheduledSuspends_;
   OfflineAudioContextResultCallback resultCallback_;
 

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioScheduledSourceNode.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioScheduledSourceNode.cpp
@@ -78,8 +78,13 @@ void AudioScheduledSourceNode::updatePlaybackInfo(
     size_t currentSampleFrame) {
   auto firstFrame = currentSampleFrame;
   size_t lastFrame = firstFrame + framesToProcess - 1;
-
-  size_t startFrame = std::max(dsp::timeToSampleFrame(startTime_, sampleRate), firstFrame);
+  size_t startFrame;
+  // initial call
+  if (startTime_ == -1) {
+    startFrame = firstFrame;
+  } else {
+    startFrame = std::max(dsp::timeToSampleFrame(startTime_, sampleRate), firstFrame);
+  }
   size_t stopFrame = stopTime_ == -1.0 ? std::numeric_limits<size_t>::max()
                                        : dsp::timeToSampleFrame(stopTime_, sampleRate);
   if (isFinished()) {

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/utils/CurrentRenderScope.h
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/utils/CurrentRenderScope.h
@@ -1,0 +1,24 @@
+#pragma once
+#include <audioapi/utils/Macros.h>
+
+#include <atomic>
+#include <cstdint>
+
+namespace {
+
+struct CurrentRenderScope {
+  explicit CurrentRenderScope(std::atomic<uint32_t> &counter) : counter_(counter) {
+    counter_.fetch_add(1, std::memory_order_acq_rel);
+  }
+
+  ~CurrentRenderScope() {
+    counter_.fetch_sub(1, std::memory_order_release);
+  }
+
+  DELETE_COPY_AND_MOVE(CurrentRenderScope);
+
+ private:
+  std::atomic<uint32_t> &counter_;
+};
+
+} // namespace

--- a/packages/react-native-audio-api/ios/audioapi/ios/core/IOSAudioPlayer.h
+++ b/packages/react-native-audio-api/ios/audioapi/ios/core/IOSAudioPlayer.h
@@ -21,7 +21,8 @@ class IOSAudioPlayer {
   IOSAudioPlayer(
       const std::function<void(std::shared_ptr<DSPAudioBuffer>, int)> &renderAudio,
       float sampleRate,
-      int channelCount);
+      int channelCount,
+      std::atomic<uint32_t> &currentRenders);
   ~IOSAudioPlayer();
 
   bool start();
@@ -42,6 +43,7 @@ class IOSAudioPlayer {
   std::shared_ptr<DSPAudioBuffer> audioBuffer_;
   NativeAudioPlayer *audioPlayer_;
   std::function<void(std::shared_ptr<DSPAudioBuffer>, int)> renderAudio_;
+  std::atomic<uint32_t> &currentRenders_;
   int channelCount_;
   std::atomic<bool> isRunning_;
   /// Set from main thread on start/resume; consumed on audio thread to drop stale pending audio.

--- a/packages/react-native-audio-api/ios/audioapi/ios/core/IOSAudioPlayer.mm
+++ b/packages/react-native-audio-api/ios/audioapi/ios/core/IOSAudioPlayer.mm
@@ -1,9 +1,11 @@
 #import <AVFoundation/AVFoundation.h>
+#include <audioapi/utils/Macros.h>
 
 #include <algorithm>
 #include <cstring>
 
 #include <audioapi/core/utils/Constants.h>
+#include <audioapi/core/utils/CurrentRenderScope.h>
 #include <audioapi/ios/core/IOSAudioPlayer.h>
 #include <audioapi/ios/system/AudioEngine.h>
 #include <audioapi/utils/AudioBuffer.hpp>
@@ -13,10 +15,12 @@ namespace audioapi {
 IOSAudioPlayer::IOSAudioPlayer(
     const std::function<void(std::shared_ptr<DSPAudioBuffer>, int)> &renderAudio,
     float sampleRate,
-    int channelCount)
+    int channelCount,
+    std::atomic<uint32_t> &currentRenders)
     : audioBuffer_(nullptr),
       audioPlayer_(nullptr),
       renderAudio_(renderAudio),
+      currentRenders_(currentRenders),
       channelCount_(channelCount),
       isRunning_(false),
       pendingSaved_(RENDER_QUANTUM_SIZE, channelCount_, sampleRate)
@@ -44,6 +48,8 @@ void IOSAudioPlayer::clearPendingSaved()
 
 void IOSAudioPlayer::deliverOutputBuffers(AudioBufferList *outputData, int numFrames)
 {
+  const CurrentRenderScope renderScope(currentRenders_);
+
   // If requested, clear any saved overflow before continuing normal rendering.
   if (flushOverflowNextPull_.exchange(false, std::memory_order_acq_rel)) {
     clearPendingSaved();
@@ -84,7 +90,11 @@ void IOSAudioPlayer::deliverOutputBuffers(AudioBufferList *outputData, int numFr
       continue;
     }
 
-    renderAudio_(audioBuffer_, RENDER_QUANTUM_SIZE);
+    if (isRunning_.load(std::memory_order_acquire)) {
+      renderAudio_(audioBuffer_, RENDER_QUANTUM_SIZE);
+    } else {
+      audioBuffer_->zero();
+    }
 
     // normal rendering - take RENDER_QUANTUM_SIZE frames from the graph and copy to output
     const int stillNeed = numFrames - outPos;

--- a/packages/react-native-audio-api/ios/audioapi/ios/core/NativeAudioPlayer.m
+++ b/packages/react-native-audio-api/ios/audioapi/ios/core/NativeAudioPlayer.m
@@ -87,10 +87,10 @@
 - (void)stop
 {
   AudioEngine *audioEngine = [AudioEngine sharedInstance];
-  assert(audioEngine != nil);
-
-  [self detachSourceNodeIfAttached:audioEngine];
-  [audioEngine stopIfPossible];
+  if (audioEngine != nil) {
+    [self detachSourceNodeIfAttached:audioEngine];
+    [audioEngine stopIfPossible];
+  }
 }
 
 - (bool)resume

--- a/packages/react-native-audio-api/ios/audioapi/ios/core/NativeAudioRecorder.h
+++ b/packages/react-native-audio-api/ios/audioapi/ios/core/NativeAudioRecorder.h
@@ -11,7 +11,7 @@ typedef void (^AudioReceiverBlock)(const AudioBufferList *inputBuffer, int numFr
 @property (nonatomic, copy) AudioReceiverBlock receiverBlock;
 @property (nonatomic, strong) AVAudioFormat *resolvedInputFormat;
 @property (nonatomic, assign) int resolvedBufferSize;
-@property (nonatomic, assign) BOOL inputArmed;
+@property (atomic, assign) BOOL inputArmed;
 
 - (instancetype)initWithReceiverBlock:(AudioReceiverBlock)receiverBlock;
 


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## ⚠️ Breaking changes ⚠️

<!-- A brief description of the breaking changes -->

-

## Introduced changes

<!-- A brief description of the changes -->

- this pr targets multiple possible race conditions when calling async functions
- removed also possible race conditions between audio and js, because of stale audio callback

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added/Conducted relevant tests
- [ ] Performed self-review of the code
- [ ] Updated Web Audio API coverage
- [ ] Added support for web
- [ ] Updated old arch android spec file
