### PR TITLE
fix: `OnAudioReadyEventType.when` support 

### DIFF
--- a/packages/react-native-audio-api/common/cpp/audioapi/core/utils/AudioRecorderCallback.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/utils/AudioRecorderCallback.cpp
@@ -71,8 +71,11 @@ void AudioRecorderCallback::invokeCallback(
         AudioEvent::AUDIO_READY,
         callbackId_,
         AudioReadyPayload{
-            .buffer = std::make_shared<AudioBufferHostObject>(buffer), .numFrames = numFrames});
+            .buffer = std::make_shared<AudioBufferHostObject>(buffer),
+            .numFrames = numFrames,
+            .when = static_cast<double>(framesEmitted_) / sampleRate_});
   }
+  framesEmitted_ += numFrames;
 }
 
 void AudioRecorderCallback::setOnErrorCallback(uint64_t callbackId) {

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/utils/AudioRecorderCallback.h
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/utils/AudioRecorderCallback.h
@@ -47,6 +47,7 @@ class AudioRecorderCallback {
   int channelCount_;
   uint64_t callbackId_;
   size_t ringBufferSize_;
+  uint64_t framesEmitted_ = 0;
 
   std::atomic<uint64_t> errorCallbackId_{0};
 

--- a/packages/react-native-audio-api/common/cpp/audioapi/events/AudioEventPayload.h
+++ b/packages/react-native-audio-api/common/cpp/audioapi/events/AudioEventPayload.h
@@ -66,6 +66,7 @@ struct BufferEndedPayload {
 struct AudioReadyPayload {
   std::shared_ptr<AudioBufferHostObject> buffer;
   int numFrames;
+  double when;
 
   facebook::jsi::Object toJsiObject(facebook::jsi::Runtime &rt) const {
     facebook::jsi::Object obj(rt);
@@ -75,9 +76,11 @@ struct AudioReadyPayload {
       obj.setProperty(rt, "buffer", facebook::jsi::Object::createFromHostObject(rt, buffer));
       obj.setProperty(rt, "numFrames", numFrames);
       obj.setExternalMemoryPressure(rt, buffer->getSizeInBytes());
+      obj.setProperty(rt, "when", when);
     } else {
       obj.setProperty(rt, "buffer", facebook::jsi::Value::null());
       obj.setProperty(rt, "numFrames", 0);
+      obj.setProperty(rt, "when", 0.0);
     }
 
     return obj;


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #1103 

## ⚠️ Breaking changes ⚠️

<!-- A brief description of the breaking changes -->

- N/A

## Introduced changes

<!-- A brief description of the changes -->

- Aligned `AudioReadyPayload` return object (`JSI`) with the `OnAudioReadyEventType` interface (`JS`-side) by adding support for `when` field

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added/Conducted relevant tests
- [x] Performed self-review of the code
- [x] Updated Web Audio API coverage
- [x] Added support for web
- [x] Updated old arch android spec file
