### PR TITLE
refactor: promises and errors

### DIFF
--- a/apps/common-app/src/demos/Record/Record.tsx
+++ b/apps/common-app/src/demos/Record/Record.tsx
@@ -63,7 +63,6 @@ const Record: FC = () => {
       setHasPermissions(true);
     }
 
-    let success = false;
     AudioManager.setAudioSessionOptions({
       iosCategory: 'playAndRecord',
       iosMode: 'default',
@@ -71,15 +70,9 @@ const Record: FC = () => {
     });
 
     try {
-      success = await AudioManager.setAudioSessionActivity(true);
+      await AudioManager.setAudioSessionActivity(true);
     } catch (error) {
       console.error(error);
-      Alert.alert('Error', 'Failed to activate audio session for recording.');
-      setState(RecordingState.Idle);
-      return;
-    }
-
-    if (!success) {
       Alert.alert('Error', 'Failed to activate audio session for recording.');
       setState(RecordingState.Idle);
       return;

--- a/apps/common-app/src/examples/AudioFile/AudioFile.tsx
+++ b/apps/common-app/src/examples/AudioFile/AudioFile.tsx
@@ -35,9 +35,10 @@ const AudioFile: FC = () => {
         iosOptions: [],
       });
 
-      const success = await AudioManager.setAudioSessionActivity(true);
-
-      if (!success) {
+      try {
+        await AudioManager.setAudioSessionActivity(true);
+      } catch (error) {
+        console.error('Failed to activate audio session:', error);
         Alert.alert(
           'Audio Session Error',
           'Failed to activate audio session for playback.'

--- a/apps/common-app/src/examples/Record/Record.tsx
+++ b/apps/common-app/src/examples/Record/Record.tsx
@@ -49,9 +49,10 @@ const Record: FC = () => {
       iosOptions: ['allowBluetoothHFP'],
     });
 
-    const success = await AudioManager.setAudioSessionActivity(true);
-
-    if (!success) {
+    try {
+      await AudioManager.setAudioSessionActivity(true);
+    } catch (error) {
+      console.error('Failed to activate audio session:', error);
       Alert.alert(
         'Audio Session Error',
         'Failed to activate audio session for recording.'
@@ -115,9 +116,10 @@ const Record: FC = () => {
       iosOptions: ['allowBluetoothA2DP', 'allowBluetoothHFP'],
     });
 
-    const success = await AudioManager.setAudioSessionActivity(true);
-
-    if (!success) {
+    try {
+      await AudioManager.setAudioSessionActivity(true);
+    } catch (error) {
+      console.error('Failed to activate audio session:', error);
       Alert.alert(
         'Audio Session Error',
         'Failed to activate audio session for recording.'
@@ -176,9 +178,10 @@ const Record: FC = () => {
       iosOptions: [],
     });
 
-    const success = await AudioManager.setAudioSessionActivity(true);
-
-    if (!success) {
+    try {
+      await AudioManager.setAudioSessionActivity(true);
+    } catch (error) {
+      console.error('Failed to activate audio session:', error);
       Alert.alert(
         'Audio Session Error',
         'Failed to activate audio session for playback.'

--- a/apps/common-app/src/other/AudioPipelineStress/AudioPipelineStress.tsx
+++ b/apps/common-app/src/other/AudioPipelineStress/AudioPipelineStress.tsx
@@ -713,11 +713,7 @@ const AudioPipelineStress: FC = () => {
                 iosOptions: [],
               });
 
-              const active = await AudioManager.setAudioSessionActivity(true);
-
-              if (!active) {
-                throw new Error('Failed to activate playback session');
-              }
+              await AudioManager.setAudioSessionActivity(true);
 
               resourcesRef.current.configureRecorderTap();
               const result = await resourcesRef.current.tryStartRecording(

--- a/apps/common-app/src/other/AudioPipelineStress/audioSessions.ts
+++ b/apps/common-app/src/other/AudioPipelineStress/audioSessions.ts
@@ -7,11 +7,7 @@ export async function activatePlaybackSession(): Promise<void> {
     iosOptions: [],
   });
 
-  const success = await AudioManager.setAudioSessionActivity(true);
-
-  if (!success) {
-    throw new Error('Failed to activate playback session');
-  }
+  await AudioManager.setAudioSessionActivity(true);
 }
 
 export async function activateRecordingSession(): Promise<void> {
@@ -21,9 +17,5 @@ export async function activateRecordingSession(): Promise<void> {
     iosOptions: ['defaultToSpeaker', 'allowBluetoothA2DP'],
   });
 
-  const success = await AudioManager.setAudioSessionActivity(true);
-
-  if (!success) {
-    throw new Error('Failed to activate recording session');
-  }
+  await AudioManager.setAudioSessionActivity(true);
 }

--- a/apps/fabric-example/ios/FabricExampleTests/AudioAPIModuleTests.mm
+++ b/apps/fabric-example/ios/FabricExampleTests/AudioAPIModuleTests.mm
@@ -131,7 +131,7 @@ static NSArray<NSString *> *CopyAudioModuleEvents(NSMutableArray<NSString *> *ev
                                resolve:^(id result) {
                                  AppendAudioModuleEvent(eventLog, @"resolve");
                                  eventsAtResolve = CopyAudioModuleEvents(eventLog);
-                                 XCTAssertEqualObjects(result, @YES);
+                                 XCTAssertNil(result);
                                  [resolveExpectation fulfill];
                                }
                                 reject:^(NSString *code, NSString *message, NSError *error) {

--- a/apps/fabric-example/ios/FabricExampleTests/AudioSessionManagerTests.mm
+++ b/apps/fabric-example/ios/FabricExampleTests/AudioSessionManagerTests.mm
@@ -238,7 +238,7 @@
   self.manager.shouldManageSession = false;
   self.fakeSession.category = AVAudioSessionCategoryRecord;
 
-  XCTAssertTrue([self.manager configureAudioSession]);
+  XCTAssertTrue([self.manager configureAudioSession:nil]);
   XCTAssertEqual(self.fakeSession.setCategoryCallCount, 0);
   XCTAssertEqual(self.fakeSession.setAllowHapticsCallCount, 0);
 }
@@ -246,7 +246,7 @@
 - (void)testConfigureAudioSessionNoOpsWhenDesiredOptionsAlreadySet
 {
   XCTAssertTrue([self.manager areDesiredOptionsSet]);
-  XCTAssertTrue([self.manager configureAudioSession]);
+  XCTAssertTrue([self.manager configureAudioSession:nil]);
   XCTAssertEqual(self.fakeSession.setCategoryCallCount, 0);
   XCTAssertEqual(self.fakeSession.setAllowHapticsCallCount, 0);
 }
@@ -263,7 +263,7 @@
   self.fakeSession.categoryOptions = AVAudioSessionCategoryOptionMixWithOthers;
   self.fakeSession.allowHapticsAndSystemSoundsDuringRecording = NO;
 
-  XCTAssertTrue([self.manager configureAudioSession]);
+  XCTAssertTrue([self.manager configureAudioSession:nil]);
   XCTAssertEqual(self.fakeSession.setCategoryCallCount, 1);
   XCTAssertEqual(self.fakeSession.setAllowHapticsCallCount, 1);
   XCTAssertEqualObjects(self.fakeSession.category, AVAudioSessionCategoryPlayAndRecord);
@@ -280,9 +280,13 @@
   self.fakeSession.setCategoryError =
       [NSError errorWithDomain:@"AudioSessionTests" code:100 userInfo:nil];
 
-  XCTAssertFalse([self.manager configureAudioSession]);
+  NSError *error = nil;
+  XCTAssertFalse([self.manager configureAudioSession:&error]);
   XCTAssertEqual(self.fakeSession.setCategoryCallCount, 1);
   XCTAssertEqual(self.fakeSession.setAllowHapticsCallCount, 0);
+  XCTAssertNotNil(error);
+  XCTAssertEqualObjects(error.domain, @"AudioSessionTests");
+  XCTAssertEqual(error.code, 100);
 }
 
 - (void)testConfigureAudioSessionReturnsFalseWhenSettingHapticsFails
@@ -293,9 +297,13 @@
   self.fakeSession.setAllowHapticsError =
       [NSError errorWithDomain:@"AudioSessionTests" code:101 userInfo:nil];
 
-  XCTAssertFalse([self.manager configureAudioSession]);
+  NSError *error = nil;
+  XCTAssertFalse([self.manager configureAudioSession:&error]);
   XCTAssertEqual(self.fakeSession.setCategoryCallCount, 1);
   XCTAssertEqual(self.fakeSession.setAllowHapticsCallCount, 1);
+  XCTAssertNotNil(error);
+  XCTAssertEqualObjects(error.domain, @"AudioSessionTests");
+  XCTAssertEqual(error.code, 101);
 }
 
 - (void)testSetAudioSessionOptionsUpdatesDesiredValuesAndReconfiguresWhenActive
@@ -410,10 +418,16 @@
   self.fakeSession.setCategoryError =
       [NSError errorWithDomain:@"AudioSessionTests" code:102 userInfo:nil];
 
-  XCTAssertFalse([self.manager activateSessionIfNeeded:false error:nil]);
+  NSError *error = nil;
+  XCTAssertFalse([self.manager activateSessionIfNeeded:false error:&error]);
   XCTAssertEqual(self.fakeSession.setCategoryCallCount, 1);
   XCTAssertEqual(self.fakeSession.setActiveCallCount, 0);
   XCTAssertFalse(self.manager.isActive);
+  // The NSError from setCategory must propagate up through configureAudioSession so the JS
+  // bridge can surface the real AVFoundation domain/code instead of an opaque "unknown error".
+  XCTAssertNotNil(error);
+  XCTAssertEqualObjects(error.domain, @"AudioSessionTests");
+  XCTAssertEqual(error.code, 102);
 }
 
 - (void)testEnsureActiveNoOpsWhenSessionManagementIsDisabled
@@ -572,7 +586,7 @@
                         reject:^(NSString *code, NSString *message, NSError *error){
                         }];
 
-  XCTAssertEqualObjects(resolvedValue, @YES);
+  XCTAssertNil(resolvedValue);
   XCTAssertEqual(self.fakeSession.setPreferredInputCallCount, 1);
   XCTAssertEqualObjects(self.fakeSession.lastPreferredInput, input);
 }

--- a/packages/audiodocs/docs/core/audio-context.mdx
+++ b/packages/audiodocs/docs/core/audio-context.mdx
@@ -54,11 +54,11 @@ Closes the audio context, releasing any system audio resources that it uses.
 Suspends time progression in the audio context.
 It is useful when your application will not use audio for a while.
 
-#### Returns `Promise<boolean>`.
+#### Returns `Promise<void>`.
 
 ### `resume`
 
 Resumes a previously suspended audio context.
 
-#### Returns `Promise<boolean>`.
+#### Returns `Promise<void>`.
 

--- a/packages/audiodocs/docs/inputs/audio-recorder.mdx
+++ b/packages/audiodocs/docs/inputs/audio-recorder.mdx
@@ -132,10 +132,10 @@ const MyRecorder: React.FC = () => {
     }
 
     // Activate audio session
-    const success = await AudioManager.setAudioSessionActivity(true);
-
-    if (!success) {
-      console.warn('Could not activate the audio session');
+    try {
+      await AudioManager.setAudioSessionActivity(true);
+    } catch (error) {
+      console.warn('Could not activate the audio session', error);
       return;
     }
 
@@ -223,10 +223,10 @@ const MyRecorder: React.FC = () => {
     }
 
     // Activate audio session
-    const success = await AudioManager.setAudioSessionActivity(true);
-
-    if (!success) {
-      console.warn('Could not activate the audio session');
+    try {
+      await AudioManager.setAudioSessionActivity(true);
+    } catch (error) {
+      console.warn('Could not activate the audio session', error);
       return;
     }
 
@@ -296,10 +296,10 @@ const MyRecorder: React.FC = () => {
     }
 
     // Activate audio session
-    const success = await AudioManager.setAudioSessionActivity(true);
-
-    if (!success) {
-      console.warn('Could not activate the audio session');
+    try {
+      await AudioManager.setAudioSessionActivity(true);
+    } catch (error) {
+      console.warn('Could not activate the audio session', error);
       return;
     }
 

--- a/packages/audiodocs/docs/system/audio-manager.mdx
+++ b/packages/audiodocs/docs/system/audio-manager.mdx
@@ -58,7 +58,7 @@ function App() {
 | :---: | :---: | :---- |
 | enabled | `boolean` | It is used to set/unset [AVAudioSession](https://developer.apple.com/documentation/avfaudio/avaudiosession?language=objc#Activating-the-audio-configuration) activity |
 
-#### Returns promise of `boolean` type, which is resolved to `true` if invokation ended with success, `false` otherwise.'
+#### Returns `Promise<void>`, which resolves when the audio session activity was set successfully. On failure the promise rejects with a `SessionActivationError` that carries the native error details (`nativeErrorInfo`) when available.
 
 ### `disableSessionManagement` <IOS />
 

--- a/packages/audiodocs/docs/worklets/worklet-node.mdx
+++ b/packages/audiodocs/docs/worklets/worklet-node.mdx
@@ -53,10 +53,7 @@ async function App() {
     const workletNode = audioContext.createWorkletNode(worklet, 1024, 2, 'UIRuntime');
     const adapterNode = audioContext.createRecorderAdapter();
 
-    const canSetAudioSessionActivity = await AudioManager.setAudioSessionActivity(true);
-    if (!canSetAudioSessionActivity) {
-        throw new Error("Could not activate the audio session");
-    }
+    await AudioManager.setAudioSessionActivity(true);
     adapterNode.connect(workletNode);
     workletNode.connect(audioContext.destination);
     recorder.connect(adapterNode);

--- a/packages/react-native-audio-api/android/src/main/java/com/swmansion/audioapi/AudioAPIModule.kt
+++ b/packages/react-native-audio-api/android/src/main/java/com/swmansion/audioapi/AudioAPIModule.kt
@@ -113,7 +113,7 @@ class AudioAPIModule(
     enabled: Boolean,
     promise: Promise?,
   ) {
-    promise?.resolve(true)
+    promise?.resolve(null)
   }
 
   override fun setAudioSessionOptions(
@@ -184,7 +184,7 @@ class AudioAPIModule(
   ) {
     // TODO: noop for now, but it should be moved to upcoming
     // audio engine implementation for android (duplex stream)
-    promise?.resolve(true)
+    promise?.resolve(null)
   }
 
   // Notification system methods

--- a/packages/react-native-audio-api/common/cpp/audioapi/HostObjects/AudioContextHostObject.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/HostObjects/AudioContextHostObject.cpp
@@ -4,6 +4,7 @@
 #include <audioapi/HostObjects/sources/MediaElementAudioSourceNodeHostObject.h>
 #include <audioapi/core/AudioContext.h>
 #include <memory>
+#include <string>
 #include <utility>
 
 namespace audioapi {
@@ -40,9 +41,12 @@ JSI_HOST_FUNCTION_IMPL(AudioContextHostObject, close) {
 JSI_HOST_FUNCTION_IMPL(AudioContextHostObject, resume) {
   auto audioContext = std::static_pointer_cast<AudioContext>(context_);
   auto promise = promiseVendor_->createAsyncPromise([audioContext = std::move(audioContext)]() {
-    auto result = audioContext->resume();
-    return [result](jsi::Runtime &runtime) {
-      return jsi::Value(result);
+    const auto result = audioContext->resume();
+    return [result](jsi::Runtime &runtime) -> std::variant<jsi::Value, std::string> {
+      if (result) {
+        return jsi::Value::undefined();
+      }
+      return std::string("Failed to resume audio context.");
     };
   });
   return promise;
@@ -51,9 +55,12 @@ JSI_HOST_FUNCTION_IMPL(AudioContextHostObject, resume) {
 JSI_HOST_FUNCTION_IMPL(AudioContextHostObject, suspend) {
   auto audioContext = std::static_pointer_cast<AudioContext>(context_);
   auto promise = promiseVendor_->createAsyncPromise([audioContext = std::move(audioContext)]() {
-    auto result = audioContext->suspend();
-    return [result](jsi::Runtime &runtime) {
-      return jsi::Value(result);
+    const auto result = audioContext->suspend();
+    return [result](jsi::Runtime &runtime) -> std::variant<jsi::Value, std::string> {
+      if (result) {
+        return jsi::Value::undefined();
+      }
+      return std::string("Failed to suspend audio context.");
     };
   });
 

--- a/packages/react-native-audio-api/ios/audioapi/ios/AudioAPIModule.mm
+++ b/packages/react-native-audio-api/ios/audioapi/ios/AudioAPIModule.mm
@@ -177,7 +177,7 @@ RCT_EXPORT_METHOD(
       }
     }
 
-    resolve(@(success));
+    resolve(nil);
   });
 }
 

--- a/packages/react-native-audio-api/ios/audioapi/ios/system/AudioSessionManager.h
+++ b/packages/react-native-audio-api/ios/audioapi/ios/system/AudioSessionManager.h
@@ -30,7 +30,7 @@
                   allowHaptics:(BOOL)allowHaptics
     notifyOthersOnDeactivation:(BOOL)notifyOthersOnDeactivation;
 
-- (bool)configureAudioSession;
+- (bool)configureAudioSession:(NSError **)outError;
 /// Ensures the library-managed session is active. In external owner mode this is a no-op.
 - (bool)ensureActive:(bool)force error:(NSError **)error;
 - (bool)setActive:(bool)active error:(NSError **)error;

--- a/packages/react-native-audio-api/ios/audioapi/ios/system/AudioSessionManager.mm
+++ b/packages/react-native-audio-api/ios/audioapi/ios/system/AudioSessionManager.mm
@@ -63,40 +63,45 @@ static AudioSessionManager *_sharedInstance = nil;
       self.audioSession.allowHapticsAndSystemSoundsDuringRecording == self.allowHapticsAndSounds);
 }
 
-- (bool)configureAudioSession
+- (bool)configureAudioSession:(NSError **)outError
 {
-  NSError *error = nil;
-
   if (!self.shouldManageSession || [self areDesiredOptionsSet]) {
     return true;
   }
 
+  NSError *categoryError = nil;
   [self.audioSession setCategory:self.desiredCategory
                             mode:self.desiredMode
                          options:self.desiredOptions
-                           error:&error];
+                           error:&categoryError];
 
-  if (error != nil) {
-    NSLog(@"Error while configuring audio session: %@", [error debugDescription]);
+  if (categoryError != nil) {
+    NSLog(@"Error while configuring audio session: %@", [categoryError debugDescription]);
+    if (outError != nil) {
+      *outError = categoryError;
+    }
     return false;
-  } else {
-    NSLog(
-        @"[AudioSessionManager] Configured audio session: category=%@, mode=%@, options=%lu",
-        self.audioSession.category,
-        self.audioSession.mode,
-        (unsigned long)self.audioSession.categoryOptions);
   }
+  NSLog(
+      @"[AudioSessionManager] Configured audio session: category=%@, mode=%@, options=%lu",
+      self.audioSession.category,
+      self.audioSession.mode,
+      (unsigned long)self.audioSession.categoryOptions);
 
   if (@available(iOS 13.0, *)) {
     if (self.audioSession.allowHapticsAndSystemSoundsDuringRecording !=
         self.allowHapticsAndSounds) {
+      NSError *hapticsError = nil;
       [self.audioSession setAllowHapticsAndSystemSoundsDuringRecording:self.allowHapticsAndSounds
-                                                                 error:&error];
+                                                                 error:&hapticsError];
 
-      if (error != nil) {
+      if (hapticsError != nil) {
         NSLog(
             @"Error while setting allowHapticsAndSystemSoundsDuringRecording: %@",
-            [error debugDescription]);
+            [hapticsError debugDescription]);
+        if (outError != nil) {
+          *outError = hapticsError;
+        }
         return false;
       }
     }
@@ -133,7 +138,7 @@ static AudioSessionManager *_sharedInstance = nil;
   self.notifyOthersOnDeactivation = notifyOthersOnDeactivation;
 
   if (configChanged && self.isActive) {
-    [self configureAudioSession];
+    [self configureAudioSession:nil];
   }
 }
 
@@ -179,7 +184,7 @@ static AudioSessionManager *_sharedInstance = nil;
     return true;
   }
 
-  if (![self configureAudioSession]) {
+  if (![self configureAudioSession:error]) {
     return false;
   }
 
@@ -427,7 +432,7 @@ static AudioSessionManager *_sharedInstance = nil;
     return;
   }
 
-  resolve(@(true));
+  resolve(nil);
 }
 
 - (AVAudioSessionCategory)categoryFromString:(NSString *)categorySTR

--- a/packages/react-native-audio-api/src/core/AudioContext.ts
+++ b/packages/react-native-audio-api/src/core/AudioContext.ts
@@ -33,12 +33,12 @@ export default class AudioContext extends BaseAudioContext {
     return (this.context as IAudioContext).close();
   }
 
-  async resume(): Promise<boolean> {
-    return (this.context as IAudioContext).resume();
+  async resume(): Promise<void> {
+    await (this.context as IAudioContext).resume();
   }
 
-  async suspend(): Promise<boolean> {
-    return (this.context as IAudioContext).suspend();
+  async suspend(): Promise<void> {
+    await (this.context as IAudioContext).suspend();
   }
 
   createMediaElementSource(

--- a/packages/react-native-audio-api/src/hooks/useAudioInput.ts
+++ b/packages/react-native-audio-api/src/hooks/useAudioInput.ts
@@ -30,11 +30,8 @@ export default function useAudioInput() {
   const [currentInput, setCurrentInput] = useState<string | null>(null);
 
   const onSelectInput = useCallback(async (device: AudioDeviceInfo) => {
-    const success = await AudioManager.setInputDevice(device.id);
-
-    if (success) {
-      setCurrentInput(device.id);
-    }
+    await AudioManager.setInputDevice(device.id);
+    setCurrentInput(device.id);
 
     const devicesInfo: AudioDevicesInfo = await AudioManager.getDevicesInfo();
     setAvailableInputs(devicesInfo.availableInputs);
@@ -83,8 +80,8 @@ export default function useAudioInput() {
        */
       currentInput: availableInputs.find((d) => d.id === currentInput) || null,
       /**
-       * Selects the given device as the current input. Returns true if
-       * successful, throws otherwise.
+       * Selects the given device as the current input. Resolves once the device
+       * is selected, throws otherwise.
        */
       onSelectInput,
     }),

--- a/packages/react-native-audio-api/src/jsi-interfaces.ts
+++ b/packages/react-native-audio-api/src/jsi-interfaces.ts
@@ -114,8 +114,8 @@ export interface IAudioContext extends IBaseAudioContext {
     mediaElement: IAudioFileSourceNode
   ) => IMediaElementAudioSourceNode;
   close(): Promise<void>;
-  resume(): Promise<boolean>;
-  suspend(): Promise<boolean>;
+  resume(): Promise<void>;
+  suspend(): Promise<void>;
 }
 
 export interface IOfflineAudioContext extends IBaseAudioContext {

--- a/packages/react-native-audio-api/src/specs/NativeAudioAPIModule.ts
+++ b/packages/react-native-audio-api/src/specs/NativeAudioAPIModule.ts
@@ -17,7 +17,7 @@ interface Spec extends TurboModule {
   getDevicePreferredSampleRate(): number;
 
   // AVAudioSession management
-  setAudioSessionActivity(enabled: boolean): Promise<boolean>;
+  setAudioSessionActivity(enabled: boolean): Promise<void>;
   setAudioSessionOptions(
     category: string,
     mode: string,
@@ -40,7 +40,7 @@ interface Spec extends TurboModule {
 
   // Audio devices
   getDevicesInfo(): Promise<AudioDevicesInfo>;
-  setInputDevice(deviceId: string): Promise<boolean>;
+  setInputDevice(deviceId: string): Promise<void>;
 
   // Notification system
   showNotification(

--- a/packages/react-native-audio-api/src/specs/NativeAudioAPIModule.web.ts
+++ b/packages/react-native-audio-api/src/specs/NativeAudioAPIModule.web.ts
@@ -17,7 +17,7 @@ interface Spec extends TurboModule {
   getDevicePreferredSampleRate(): number;
 
   // AVAudioSession management
-  setAudioSessionActivity(enabled: boolean): Promise<boolean>;
+  setAudioSessionActivity(enabled: boolean): Promise<void>;
   setAudioSessionOptions(
     category: string,
     mode: string,
@@ -40,7 +40,7 @@ interface Spec extends TurboModule {
 
   // Audio devices
   getDevicesInfo(): Promise<AudioDevicesInfo>;
-  setInputDevice(deviceId: string): Promise<boolean>;
+  setInputDevice(deviceId: string): Promise<void>;
 
   // New notification system
   showNotification(
@@ -65,7 +65,7 @@ const mockSync =
 const NativeAudioAPIModule: Spec = {
   install: mockSync(true),
   getDevicePreferredSampleRate: mockSync(0),
-  setAudioSessionActivity: mockAsync(true),
+  setAudioSessionActivity: mockAsync(undefined),
   setAudioSessionOptions: mockSync({}),
   disableSessionManagement: mockSync({}),
   observeAudioInterruptions: mockSync({}),
@@ -81,7 +81,7 @@ const NativeAudioAPIModule: Spec = {
     currentInputs: [],
     currentOutputs: [],
   }),
-  setInputDevice: mockAsync(true),
+  setInputDevice: mockAsync(undefined),
   showNotification: mockAsync({ success: true }),
   hideNotification: mockAsync({ success: true }),
   isNotificationActive: mockAsync(false),

--- a/packages/react-native-audio-api/src/system/AudioManager.ts
+++ b/packages/react-native-audio-api/src/system/AudioManager.ts
@@ -22,12 +22,16 @@ class AudioManager implements IAudioManager {
     return NativeAudioAPIModule.getDevicePreferredSampleRate();
   }
 
-  async setAudioSessionActivity(enabled: boolean): Promise<boolean> {
+  /**
+   * Activates or deactivates the audio session.
+   *
+   * Resolves when the session activity was set successfully. On failure it
+   * rejects with a {@link SessionActivationError} carrying the native error
+   * details (`nativeErrorInfo`) when available.
+   */
+  async setAudioSessionActivity(enabled: boolean): Promise<void> {
     try {
-      const success =
-        await NativeAudioAPIModule.setAudioSessionActivity(enabled);
-
-      return success;
+      await NativeAudioAPIModule.setAudioSessionActivity(enabled);
     } catch (error) {
       throw parseNativeError(error);
     }
@@ -104,8 +108,14 @@ class AudioManager implements IAudioManager {
     return NativeAudioAPIModule.getDevicesInfo();
   }
 
-  async setInputDevice(deviceId: string): Promise<boolean> {
-    return NativeAudioAPIModule.setInputDevice(deviceId);
+  /**
+   * Selects the given device as the current audio input.
+   *
+   * Resolves when the input device was set successfully and rejects when the
+   * device cannot be found or the system fails to switch to it.
+   */
+  async setInputDevice(deviceId: string): Promise<void> {
+    await NativeAudioAPIModule.setInputDevice(deviceId);
   }
 }
 

--- a/packages/react-native-audio-api/src/system/types.ts
+++ b/packages/react-native-audio-api/src/system/types.ts
@@ -74,7 +74,7 @@ export interface AudioDevicesInfo {
 
 export interface IAudioManager {
   getDevicePreferredSampleRate(): number;
-  setAudioSessionActivity(enabled: boolean): Promise<boolean>;
+  setAudioSessionActivity(enabled: boolean): Promise<void>;
   setAudioSessionOptions(options: SessionOptions): void;
   disableSessionManagement(): void;
   observeAudioInterruptions(enabled: boolean): void;
@@ -89,5 +89,5 @@ export interface IAudioManager {
   requestNotificationPermissions(): Promise<PermissionStatus>;
   checkNotificationPermissions(): Promise<PermissionStatus>;
   getDevicesInfo(): Promise<AudioDevicesInfo>;
-  setInputDevice(deviceId: string): Promise<boolean>;
+  setInputDevice(deviceId: string): Promise<void>;
 }

--- a/packages/react-native-audio-api/src/web-system/AudioManager.ts
+++ b/packages/react-native-audio-api/src/web-system/AudioManager.ts
@@ -11,7 +11,7 @@ const mockSync =
 
 class AudioManager implements IAudioManager {
   getDevicePreferredSampleRate = mockSync(44100);
-  setAudioSessionActivity = mockAsync(true);
+  setAudioSessionActivity = mockAsync(undefined);
   setAudioSessionOptions = mockSync({});
   disableSessionManagement = mockSync({});
   observeAudioInterruptions = mockSync(true);
@@ -22,7 +22,7 @@ class AudioManager implements IAudioManager {
   checkRecordingPermissions = mockAsync('Granted' as PermissionStatus);
   requestNotificationPermissions = mockAsync('Granted' as PermissionStatus);
   checkNotificationPermissions = mockAsync('Granted' as PermissionStatus);
-  setInputDevice = mockAsync(true);
+  setInputDevice = mockAsync(undefined);
   getDevicesInfo = mockAsync({
     availableInputs: [],
     availableOutputs: [],


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #1116 

## ⚠️ Breaking changes ⚠️

<!-- A brief description of the breaking changes -->

- context's methods `resume` and `suspend` now returns `Promise<void>` instead of `Promise<boolean`
- `setAudioSessionActivity` now returns `Promise<void>` instead of `Promise<boolean`
- `setInputDevice` now returns `Promise<void>` instead of `Promise<boolean`

## Introduced changes

<!-- A brief description of the changes -->

- replaced returning value of context method to match web spec
- replaced returning vales of some audio manager methods
- improved ios error logging

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added/Conducted relevant tests
- [ ] Performed self-review of the code
- [ ] Updated Web Audio API coverage
- [ ] Added support for web
- [ ] Updated old arch android spec file
