### PR TITLE
fix: running out of free pools in mpmc

### DIFF
--- a/packages/react-native-audio-api/common/cpp/audioapi/events/AudioEventHandlerRegistry.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/events/AudioEventHandlerRegistry.cpp
@@ -80,11 +80,8 @@ bool AudioEventHandlerRegistry::dispatchEvent(
   if (runtime_ == nullptr) {
     return false;
   }
-  if (!dispatchQueue_.try_enqueue(
-          DispatchEvent{
-              .event = eventName, .listenerId = listenerId, .payload = std::move(payload)})) {
-    return false;
-  }
+  dispatchQueue_.enqueue(
+      DispatchEvent{.event = eventName, .listenerId = listenerId, .payload = std::move(payload)});
   itemsAvailable_.signal();
   return true;
 }

--- a/packages/react-native-audio-api/common/cpp/audioapi/events/AudioEventHandlerRegistry.h
+++ b/packages/react-native-audio-api/common/cpp/audioapi/events/AudioEventHandlerRegistry.h
@@ -51,7 +51,7 @@ class AudioEventHandlerRegistry : public IAudioEventHandlerRegistry,
 
   void unregisterHandler(AudioEvent eventName, uint64_t listenerId) override;
 
-  /// @brief Enqueue an event from a non-audio thread. Lock-free; drops when the queue is full.
+  /// @brief Enqueue an event from a non-audio thread.
   bool dispatchEvent(
       AudioEvent eventName,
       uint64_t listenerId,


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## ⚠️ Breaking changes ⚠️

<!-- A brief description of the breaking changes -->

-

## Introduced changes

<!-- A brief description of the changes -->

- `try_enqueue` in non audio thread path did not use any token, which was using preallocated free pool in mpmc, which could be drained after running this function on few threads, current `enqueue` version makes those calls always safe and they can be blocking, because we are not on audio thread

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added/Conducted relevant tests
- [ ] Performed self-review of the code
- [ ] Updated Web Audio API coverage
- [ ] Added support for web
- [ ] Updated old arch android spec file
