### PR TITLE
fix: removed dropping broadcast events

### DIFF
--- a/apps/common-app/src/demos/Record/Record.tsx
+++ b/apps/common-app/src/demos/Record/Record.tsx
@@ -1,6 +1,7 @@
-import React, { FC, useCallback, useEffect, useState } from 'react';
+import React, { FC, useCallback, useEffect, useRef, useState } from 'react';
 import {
   AudioBuffer,
+  AudioBufferSourceNode,
   AudioManager,
   concatAudioFiles,
   FileFormat,
@@ -26,6 +27,17 @@ const Record: FC = () => {
     null
   );
   const currentPositionSV = useSharedValue(0);
+  const playbackSourceRef = useRef<AudioBufferSourceNode | null>(null);
+
+  const stopPlayback = useCallback(() => {
+    const source = playbackSourceRef.current;
+    if (source) {
+      source.onEnded = null;
+      source.disconnect();
+      playbackSourceRef.current = null;
+    }
+    currentPositionSV.value = 0;
+  }, [currentPositionSV]);
 
   const updateNotification = (paused: boolean) => {
     RecordingNotificationManager.show({
@@ -138,14 +150,23 @@ const Record: FC = () => {
       return;
     }
 
+    stopPlayback();
+
     const source = audioContext.createBufferSource();
     source.buffer = recordedBuffer;
     source.connect(audioContext.destination);
-    source.start(audioContext.currentTime);
+
+    // Keep the source alive until playback ends. Without a ref, release builds can
+    // GC the HostObject before onEnded fires; its destructor clears the native
+    // callback id and the UI never leaves the Playing state.
+    playbackSourceRef.current = source;
 
     source.onEnded = () => {
+      stopPlayback();
       setState(RecordingState.Idle);
     };
+
+    source.start(audioContext.currentTime);
 
     setTimeout(() => {
       currentPositionSV.value = withTiming(recordedBuffer.duration, {
@@ -155,7 +176,7 @@ const Record: FC = () => {
     }, 100);
 
     setState(RecordingState.Playing);
-  }, [state, recordedBuffer, currentPositionSV]);
+  }, [state, recordedBuffer, currentPositionSV, stopPlayback]);
 
   const onToggleState = useCallback(
     (action: RecordingState) => {
@@ -180,6 +201,7 @@ const Record: FC = () => {
         if (state === RecordingState.Recording) {
           onStopRecording();
         } else if (state === RecordingState.Playing) {
+          stopPlayback();
           setState(RecordingState.Idle);
         }
         return;
@@ -201,6 +223,7 @@ const Record: FC = () => {
       onStopRecording,
       onResumeRecording,
       onPlayRecording,
+      stopPlayback,
     ]
   );
 
@@ -242,12 +265,13 @@ const Record: FC = () => {
     Recorder.enableFileOutput({ rotateIntervalBytes: 1_000_000, format: FileFormat.M4A });
 
     return () => {
+      stopPlayback();
       Recorder.disableFileOutput();
       Recorder.stop();
       AudioManager.setAudioSessionActivity(false);
       RecordingNotificationManager.hide();
     };
-  }, []);
+  }, [stopPlayback]);
 
   return (
     <Container disablePadding>

--- a/packages/react-native-audio-api/common/cpp/audioapi/events/AudioEventHandlerRegistry.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/events/AudioEventHandlerRegistry.cpp
@@ -107,9 +107,6 @@ void AudioEventHandlerRegistry::handleEventOnJSThread(
     AudioEvent eventName,
     uint64_t listenerId,
     const AudioEventPayload &payload) {
-  if (listenerId == 0) {
-    return;
-  }
 
   // Collect the matching handlers under the lock, then release it before
   // invoking. invokeHandler() calls into JS, which may re-enter


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## ⚠️ Breaking changes ⚠️

<!-- A brief description of the breaking changes -->

-

## Introduced changes

<!-- A brief description of the changes -->

- notification events fire broadcast events, which they are marked as 0 id, but they were skipped in the event invocation

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added/Conducted relevant tests
- [ ] Performed self-review of the code
- [ ] Updated Web Audio API coverage
- [ ] Added support for web
- [ ] Updated old arch android spec file
