### PR TITLE
fix(recorder) fileNamePrefix works with rotateIntervalBytes

### DIFF
--- a/packages/react-native-audio-api/android/src/main/cpp/audioapi/android/core/utils/AndroidRotatingFileWriter.cpp
+++ b/packages/react-native-audio-api/android/src/main/cpp/audioapi/android/core/utils/AndroidRotatingFileWriter.cpp
@@ -29,7 +29,7 @@ OpenFileResult AndroidRotatingFileWriter::openFile(
   streamChannelCount_ = streamChannelCount;
   streamMaxBufferSize_ = streamMaxBufferSizeInFrames;
   if (!fileNameOverride.empty()) {
-    fileProperties_->fileNamePrefix = fileNameOverride;
+    fileProperties_->fileNamePrefix = fileNameOverride + fileProperties_->fileNamePrefix;
   }
   if (currentWriter_ == nullptr) {
     currentWriter_ = writerFactory_(fileProperties_);

--- a/packages/react-native-audio-api/android/src/main/cpp/audioapi/android/core/utils/AndroidRotatingFileWriter.cpp
+++ b/packages/react-native-audio-api/android/src/main/cpp/audioapi/android/core/utils/AndroidRotatingFileWriter.cpp
@@ -28,7 +28,9 @@ OpenFileResult AndroidRotatingFileWriter::openFile(
   streamSampleRate_ = streamSampleRate;
   streamChannelCount_ = streamChannelCount;
   streamMaxBufferSize_ = streamMaxBufferSizeInFrames;
-  fileProperties_->fileNamePrefix = !fileNameOverride.empty() ? fileNameOverride : "recording";
+  if (!fileNameOverride.empty()) {
+    fileProperties_->fileNamePrefix = fileNameOverride;
+  }
   if (currentWriter_ == nullptr) {
     currentWriter_ = writerFactory_(fileProperties_);
   }

--- a/packages/react-native-audio-api/ios/audioapi/ios/core/utils/IOSRotatingFileWriter.mm
+++ b/packages/react-native-audio-api/ios/audioapi/ios/core/utils/IOSRotatingFileWriter.mm
@@ -36,7 +36,9 @@ OpenFileResult IOSRotatingFileWriter::openFile(
 {
   streamFormat_ = streamFormat;
   streamMaxBufferSizeInFrames_ = streamMaxBufferSizeInFrames;
-  fileProperties_->fileNamePrefix = !fileNameOverride.empty() ? fileNameOverride : "recording";
+  if (!fileNameOverride.empty()) {
+    fileProperties_->fileNamePrefix = fileNameOverride;
+  }
   if (currentWriter_ == nullptr) {
     currentWriter_ = writerFactory_(fileProperties_);
   }

--- a/packages/react-native-audio-api/ios/audioapi/ios/core/utils/IOSRotatingFileWriter.mm
+++ b/packages/react-native-audio-api/ios/audioapi/ios/core/utils/IOSRotatingFileWriter.mm
@@ -37,7 +37,7 @@ OpenFileResult IOSRotatingFileWriter::openFile(
   streamFormat_ = streamFormat;
   streamMaxBufferSizeInFrames_ = streamMaxBufferSizeInFrames;
   if (!fileNameOverride.empty()) {
-    fileProperties_->fileNamePrefix = fileNameOverride;
+    fileProperties_->fileNamePrefix = fileNameOverride + fileProperties_->fileNamePrefix;
   }
   if (currentWriter_ == nullptr) {
     currentWriter_ = writerFactory_(fileProperties_);


### PR DESCRIPTION
The rotating file writer was ignoring the fileNamePrefix.

Closes #1137

## Introduced changes

Fixes rotating writers.

## Checklist

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added/Conducted relevant tests
- [x] Performed self-review of the code
- [x] Updated Web Audio API coverage
- [x] Added support for web
- [x] Updated old arch android spec file
