### PR TITLE
fix: add libworklets.so to exclude list

### DIFF
--- a/packages/react-native-audio-api/android/build.gradle
+++ b/packages/react-native-audio-api/android/build.gradle
@@ -216,6 +216,7 @@ android {
       "**/librrc_root.so",
       "**/libjscexecutor.so",
       "**/libv8executor.so",
+      "**/libworklets.so",
       "**/libreanimated.so"
     ]
   }


### PR DESCRIPTION
Keeping libworklets out of prebuilded aar like other libs based on worklets
- https://github.com/software-mansion/react-native-reanimated/blob/main/packages/react-native-reanimated/android/build.gradle.kts#L235

this keeps libworklets.so out of aar precompiled package.

## ⚠️ Breaking changes ⚠️

none

## Introduced changes

excluded libworklets.so from packaging jnilibs

## Checklist

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added/Conducted relevant tests
- [x] Performed self-review of the code
- [x] Updated Web Audio API coverage
- [x] Added support for web
- [x] Updated old arch android spec file
