### PR TITLE
fix: `audiodocs` eslint

### DIFF
--- a/packages/audiodocs/.eslintrc
+++ b/packages/audiodocs/.eslintrc
@@ -5,5 +5,6 @@
       "presets": ["@babel/preset-react"],
       "plugins": ["react-native-worklets/plugin"]
     }
-  }
+  },
+  "ignorePatterns": ["static"]
 }

--- a/packages/audiodocs/docusaurus.config.js
+++ b/packages/audiodocs/docusaurus.config.js
@@ -4,7 +4,7 @@
 const lightCodeTheme = require('./src/theme/CodeBlock/highlighting-light.js');
 const darkCodeTheme = require('./src/theme/CodeBlock/highlighting-dark.js');
 
-import { topbarBannerReservationScript } from '@swmansion/t-rex-ui/topbar-banner'; // eslint-disable-line import/first
+import { topbarBannerReservationScript } from '@swmansion/t-rex-ui/topbar-banner'; // eslint-disable-line import/first, import/no-unresolved
 // @ts-expect-error -- .ts extension is intentional; not type-checked by tsc here.
 import { TOP_BAR_BANNER } from './src/components/topbarBanner.config.ts'; // eslint-disable-line import/first
 

--- a/packages/audiodocs/package.json
+++ b/packages/audiodocs/package.json
@@ -49,7 +49,7 @@
     "react-dom": "^19.1.1",
     "react-draggable": "^4.4.5",
     "react-native": "^0.71.4",
-    "react-native-audio-api": "*",
+    "react-native-audio-api": "latest",
     "react-native-canvas": "^0.1.40",
     "react-native-gesture-handler": "^2.16.0",
     "react-native-reanimated": "^4.0.3",

--- a/packages/audiodocs/sidebars.js
+++ b/packages/audiodocs/sidebars.js
@@ -5,9 +5,9 @@
  - create an ordered group of docs
  - render a sidebar for each doc of that group
  - provide next/previous navigation
-
+ 
  The sidebars can be generated from the filesystem, or explicitly defined here.
-
+ 
  Create as many sidebars as you want.
  */
 const sidebars = {

--- a/packages/audiodocs/src/components/InteractivePlayground/AudioBufferSourceExample/AudioBufferSourceExample.tsx
+++ b/packages/audiodocs/src/components/InteractivePlayground/AudioBufferSourceExample/AudioBufferSourceExample.tsx
@@ -83,7 +83,7 @@ const AudioBufferSourceExample: FC<AudioBufferSourceExampleProps> = (props) => {
         setIsPlaying(false);
       }
     };
-  }, [stopSound, playbackRate,detune,loop,loopStart,loopEnd, pitchCorrection]); 
+  }, [stopSound, playbackRate, detune, loop, loopStart, loopEnd, pitchCorrection]); 
 
   const handlePlayButtonClick = () => {
     if (isPlaying) {

--- a/packages/audiodocs/static/signalsmithStretch.mjs
+++ b/packages/audiodocs/static/signalsmithStretch.mjs
@@ -470,10 +470,19 @@ function registerWorkletProcessor(Module, audioNodeKey) {
           return result;
         },
         schedule: (objIn, adjustPrevious) => {
-          let outputTime = 'output' in objIn ? objIn.output : currentTime;
-          let latestSegment = this.timeMap[this.timeMap.length - 1];
-          while (this.timeMap.length && this.timeMap[this.timeMap.length - 1].output >= outputTime) {
-            latestSegment = this.timeMap.pop();
+          let outputTime = 'output' in objIn && objIn.output !== undefined ? objIn.output : currentTime;
+          let latestSegment = this.timeMap[0];
+          for (let i = 0; i < this.timeMap.length; i++) {
+            if (this.timeMap[i].output <= outputTime) {
+              latestSegment = this.timeMap[i];
+            } else {
+              break;
+            }
+          }
+          const existingIndex = this.timeMap.findIndex(segment => segment.output === outputTime);
+          if (existingIndex >= 0) {
+            latestSegment = this.timeMap[existingIndex];
+            this.timeMap.splice(existingIndex, 1);
           }
           let obj = {
             active: latestSegment.active,
@@ -489,7 +498,12 @@ function registerWorkletProcessor(Module, audioNodeKey) {
             let rate = latestSegment.active ? latestSegment.rate : 0;
             obj.input = latestSegment.input + (obj.output - latestSegment.output) * rate;
           }
-          this.timeMap.push(obj);
+          const insertAt = existingIndex >= 0 ? existingIndex : this.timeMap.findIndex(segment => segment.output > outputTime);
+          if (insertAt === -1) {
+            this.timeMap.push(obj);
+          } else {
+            this.timeMap.splice(insertAt, 0, obj);
+          }
           if (adjustPrevious && this.timeMap.length > 1) {
             let previous = this.timeMap[this.timeMap.length - 2];
             if (previous.output < currentTime) {
@@ -500,12 +514,12 @@ function registerWorkletProcessor(Module, audioNodeKey) {
             previous.rate = (obj.input - previous.input) / (obj.output - previous.output);
           }
           let currentMapSegment = this.timeMap[0];
-          while (this.timeMap.length > 1 && this.timeMap[1].output <= outputTime) {
+          while (this.timeMap.length > 1 && this.timeMap[1].output <= currentTime) {
             this.timeMap.shift();
             currentMapSegment = this.timeMap[0];
           }
           let rate = currentMapSegment.active ? currentMapSegment.rate : 0;
-          let inputTime = currentMapSegment.input + (outputTime - currentMapSegment.output) * rate;
+          let inputTime = currentMapSegment.input + (currentTime - currentMapSegment.output) * rate;
           this.timeIntervalCounter = this.timeIntervalSamples;
           this.port.postMessage(['time', inputTime]);
           return obj;

--- a/packages/audiodocs/types.d.ts
+++ b/packages/audiodocs/types.d.ts
@@ -10,3 +10,5 @@ module "*.svg" {
   const ReactComponent: React.FC<React.SVGProps<SVGSVGElement>>;
   export default ReactComponent;
 }
+
+declare module '@swmansion/t-rex-ui/topbar-banner';

--- a/packages/audiodocs/yarn.lock
+++ b/packages/audiodocs/yarn.lock
@@ -12051,10 +12051,12 @@ react-loadable-ssr-addon-v5-slorber@^1.0.1:
   dependencies:
     "@types/react" "*"
 
-react-native-audio-api@*:
-  version "0.8.2"
-  resolved "https://registry.yarnpkg.com/react-native-audio-api/-/react-native-audio-api-0.8.2.tgz#5deb4ffe07538b8d1c747af3903025632a23f6a2"
-  integrity sha512-p+a7gL1wy09yXoqUTYdO+tAQe/G7DpWFrFUDULu4dFUsyPaVd0T10Y7Nf5P391Ldg5A6F/aIfoUtKf150RyKmw==
+react-native-audio-api@latest:
+  version "0.13.1"
+  resolved "https://registry.yarnpkg.com/react-native-audio-api/-/react-native-audio-api-0.13.1.tgz#e998747f490ae0b638106a2e719d4f9e5483b924"
+  integrity sha512-FuUcj/flfWImRFQkxpJVJe0HueQxwliCjeI+kVcWQPOj46mkpsbEhvNF0IPRNwWiDl1GaiYka8oLShZ+Y7Y9OA==
+  dependencies:
+    semver "^7.7.3"
 
 react-native-canvas@^0.1.40:
   version "0.1.40"
@@ -12913,6 +12915,11 @@ semver@^6.3.0, semver@^6.3.1:
   version "6.3.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
+
+semver@^7.7.3:
+  version "7.8.5"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.8.5.tgz#39b646037dd50c14fb451e7e4cac58ed8b863f69"
+  integrity sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==
 
 send@0.19.0:
   version "0.19.0"


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## ⚠️ Breaking changes ⚠️

<!-- A brief description of the breaking changes -->

- N/A

## Introduced changes

<!-- A brief description of the changes -->

- fixed `eslint` errors
- bumped library version to the `latest`:
  - changed library version resolution from `"*"` to `"latest"` so that any `yarn install` in `packages/audiodocs` always pulls latest version from `npm`. The deploy job is unaffected though as it pulls from `yarn` cache, based on the lockfile.

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added/Conducted relevant tests
- [x] Performed self-review of the code
- [x] Updated Web Audio API coverage
- [x] Added support for web
- [x] Updated old arch android spec file
