### PR TITLE
Refactor/prebuilt binaries downloading

### DIFF
--- a/.claude/skills/build-compilation-dependencies/SKILL.md
+++ b/.claude/skills/build-compilation-dependencies/SKILL.md
@@ -65,8 +65,8 @@ https://github.com/software-mansion-labs/rn-audio-libs/releases/download/<TAG>/
 Current tag: **v3.0.0** (see `scripts/download-prebuilt-binaries.sh`).
 
 The download script is triggered automatically:
-- **iOS**: by podspec `prepare_command` during `pod install`
-- **Android**: by `downloadPrebuiltBinaries` Gradle task, which runs before `preBuild`
+- **iOS**: by podspec `prepare_command` during `pod install` — downloads `ffmpeg_ios`, `iphoneos`, `iphonesimulator`, `macosx`
+- **Android**: by `downloadPrebuiltBinaries` Gradle task, which runs before `preBuild` — downloads `android`, `jniLibs`
 
 Downloaded artifacts land in:
 - `common/cpp/audioapi/external/android/<ABI>/` — `.a` static libs for Android ABIs

--- a/.claude/skills/build-compilation-dependencies/SKILL.md
+++ b/.claude/skills/build-compilation-dependencies/SKILL.md
@@ -65,8 +65,10 @@ https://github.com/software-mansion-labs/rn-audio-libs/releases/download/<TAG>/
 Current tag: **v3.0.0** (see `scripts/download-prebuilt-binaries.sh`).
 
 The download script is triggered automatically:
-- **iOS**: by podspec `prepare_command` during `pod install` — downloads `ffmpeg_ios`, `iphoneos`, `iphonesimulator`, `macosx`
+- **iOS**: by podspec `prepare_command` during `pod install` **and** by a `script_phase` (`[CP-User] Download RNAudioAPI prebuilt binaries`, `:before_headers`, always-out-of-date) on every Xcode build — downloads `ffmpeg_ios`, `iphoneos`, `iphonesimulator`, `macosx`. `prepare_command` ensures all vendored `.xcframework`s exist when CocoaPods generates `[CP] Copy XCFrameworks` (required for correct FFmpeg linking). The build-time phase handles CI setups that cache `Pods/` independently from `node_modules/` — it is a fast no-op when binaries are already present. **It must use `:before_headers`, not `:before_compile`** — CocoaPods inserts its own `[CP] Copy XCFrameworks` phase right after `Headers`; `:before_compile` would land *after* it. The phase's `output_files` declares both the `-force_load` static libs and the four FFmpeg xcframeworks. The whole phase is skipped only when *both* `DISABLE_AUDIOAPI_STATIC_EXTERNAL_LIBS` and `DISABLE_AUDIOAPI_FFMPEG` are set.
 - **Android**: by `downloadPrebuiltBinaries` Gradle task, which runs before `preBuild` — downloads `android`, `jniLibs`
+
+The script is idempotent — it skips any archive whose destination directory already exists, so the per-build invocations are fast no-ops once binaries are present.
 
 Downloaded artifacts land in:
 - `common/cpp/audioapi/external/android/<ABI>/` — `.a` static libs for Android ABIs

--- a/.claude/skills/build-compilation-dependencies/SKILL.md
+++ b/.claude/skills/build-compilation-dependencies/SKILL.md
@@ -112,6 +112,7 @@ For full per-line analysis see [build-details.md](build-details.md#android-andro
 - `Accelerate` framework linked, enabling `HAVE_ACCELERATE=1` for vDSP SIMD on iOS
 - Header search paths split: `pod_target_xcconfig` (library compilation) vs `xcconfig` (app consumers)
 - `rnaa_utils.rb` resolves dynamic paths at `pod install` time (not hardcoded)
+- JSI internals use distinct names (`HostObject`, `RuntimeInstanceCache`, `RuntimeObserver`) instead of generic names like `JsiHostObject` / `RuntimeAwareCache` / `RuntimeLifecycleMonitor` — `react-native-skia` publishes headers with those generic names and CocoaPods can resolve the wrong file when both libraries are in the same app
 
 For full per-line analysis see [build-details.md](build-details.md#ios-rnaudioapipodspec--detailed-analysis).
 

--- a/.claude/skills/host-objects/SKILL.md
+++ b/.claude/skills/host-objects/SKILL.md
@@ -40,7 +40,7 @@ Every audio node has three layers. HostObject is the middle one:
 ```mermaid
 flowchart TD
   TS["TypeScript class\n(src/core/)"]
-  HO["HostObject\n(C++ — JsiHostObject subclass)"]
+  HO["HostObject\n(C++ — audioapi::HostObject subclass)"]
   AN["AudioNode\n(C++ core — audio thread)"]
 
   TS <--> |"JSI — direct memory, no serialization"| HO
@@ -99,7 +99,7 @@ HostObjects/
 
 ## Macro System
 
-All HostObjects use macros defined in `jsi/JsiHostObject.h`. Always use these — never write raw JSI dispatch code.
+All HostObjects use macros defined in `jsi/HostObject.h`. Always use these — never write raw JSI dispatch code.
 
 ### Declaration macros (in .h)
 

--- a/.claude/skills/host-objects/maintenance.md
+++ b/.claude/skills/host-objects/maintenance.md
@@ -7,7 +7,7 @@ Review this skill when `pre-push-update` reports changes in:
 | Path | What to check |
 |---|---|
 | `common/cpp/audioapi/HostObjects/**` | New HostObjects, macro usage changes, shadow state patterns |
-| `common/cpp/audioapi/jsi/JsiHostObject.*` | Macro signatures, new export macros — update both `SKILL.md` and `examples.md` |
+| `common/cpp/audioapi/jsi/HostObject.*` | Macro signatures, new export macros — update both `SKILL.md` and `examples.md` |
 | `common/cpp/audioapi/HostObjects/BaseAudioContextHostObject.*` | Factory wiring section (3-step checklist) |
 | Any new `*HostObject.h` | Add to directory structure, document any new patterns it introduces |
 | `common/cpp/audioapi/HostObjects/effects/GainNodeHostObject.*` | `examples.md` — macro usage, AudioParam wrapping pattern |

--- a/apps/fabric-example/ios/FabricExample.xcodeproj/project.pbxproj
+++ b/apps/fabric-example/ios/FabricExample.xcodeproj/project.pbxproj
@@ -7,11 +7,11 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1050F6737024FB405F115BFA /* libPods-FabricExampleTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 41016FD6C289B5352D135325 /* libPods-FabricExampleTests.a */; };
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		761780ED2CA45674006654EE /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 761780EC2CA45674006654EE /* AppDelegate.swift */; };
 		81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */; };
 		88485BE83AA320DC6673875F /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB81A68108700A75B9A /* PrivacyInfo.xcprivacy */; };
-		9431C8C4ED3457D596A01B6D /* libPods-FabricExample.a in Frameworks */ = {isa = PBXBuildFile; fileRef = AC66076F8C982497E228877B /* libPods-FabricExample.a */; };
 		A1B2C3D41E00000100A0A001 /* AudioEngineTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D61E00000100A0A001 /* AudioEngineTests.mm */; };
 		A1B2C3E01E00000100A0A001 /* AudioSessionManagerTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3E11E00000100A0A001 /* AudioSessionManagerTests.mm */; };
 		A1B2C3F01E00000100A0A001 /* SystemNotificationManagerTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3F11E00000100A0A001 /* SystemNotificationManagerTests.mm */; };
@@ -19,7 +19,7 @@
 		A1B2C4101E00000100A0A001 /* NativeAudioRecorderTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C4111E00000100A0A001 /* NativeAudioRecorderTests.mm */; };
 		A1B2C4201E00000100A0A001 /* IOSAudioRecorderTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C4211E00000100A0A001 /* IOSAudioRecorderTests.mm */; };
 		A1B2C4301E00000100A0A001 /* AudioAPIModuleTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C4311E00000100A0A001 /* AudioAPIModuleTests.mm */; };
-		C6B1CAFF6291E45DDBE7E1F7 /* libPods-FabricExampleTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = A00102112FA5D4913944E288 /* libPods-FabricExampleTests.a */; };
+		E0C4BF4B755B737C4C5540FD /* libPods-FabricExample.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 241D7C6CA3A04635173C2709 /* libPods-FabricExample.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -37,12 +37,10 @@
 		13B07FB51A68108700A75B9A /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = FabricExample/Images.xcassets; sourceTree = "<group>"; };
 		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = FabricExample/Info.plist; sourceTree = "<group>"; };
 		13B07FB81A68108700A75B9A /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = PrivacyInfo.xcprivacy; path = FabricExample/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
-		50CA7291BB5F88710E5BAE88 /* Pods-FabricExampleTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FabricExampleTests.debug.xcconfig"; path = "Target Support Files/Pods-FabricExampleTests/Pods-FabricExampleTests.debug.xcconfig"; sourceTree = "<group>"; };
-		6990A9CF6077081C2F380E7F /* Pods-FabricExampleTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FabricExampleTests.release.xcconfig"; path = "Target Support Files/Pods-FabricExampleTests/Pods-FabricExampleTests.release.xcconfig"; sourceTree = "<group>"; };
+		241D7C6CA3A04635173C2709 /* libPods-FabricExample.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-FabricExample.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		41016FD6C289B5352D135325 /* libPods-FabricExampleTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-FabricExampleTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		761780EC2CA45674006654EE /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = FabricExample/AppDelegate.swift; sourceTree = "<group>"; };
 		81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = LaunchScreen.storyboard; path = FabricExample/LaunchScreen.storyboard; sourceTree = "<group>"; };
-		93C74A141660B02FBC0D26CB /* Pods-FabricExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FabricExample.release.xcconfig"; path = "Target Support Files/Pods-FabricExample/Pods-FabricExample.release.xcconfig"; sourceTree = "<group>"; };
-		A00102112FA5D4913944E288 /* libPods-FabricExampleTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-FabricExampleTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		A1B2C3D51E00000100A0A001 /* FabricExampleTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FabricExampleTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		A1B2C3D61E00000100A0A001 /* AudioEngineTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = AudioEngineTests.mm; sourceTree = "<group>"; };
 		A1B2C3E11E00000100A0A001 /* AudioSessionManagerTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = AudioSessionManagerTests.mm; sourceTree = "<group>"; };
@@ -51,9 +49,11 @@
 		A1B2C4111E00000100A0A001 /* NativeAudioRecorderTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = NativeAudioRecorderTests.mm; sourceTree = "<group>"; };
 		A1B2C4211E00000100A0A001 /* IOSAudioRecorderTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = IOSAudioRecorderTests.mm; sourceTree = "<group>"; };
 		A1B2C4311E00000100A0A001 /* AudioAPIModuleTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = AudioAPIModuleTests.mm; sourceTree = "<group>"; };
-		AC66076F8C982497E228877B /* libPods-FabricExample.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-FabricExample.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		E224256D1CD024C67AF02169 /* Pods-FabricExample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FabricExample.debug.xcconfig"; path = "Target Support Files/Pods-FabricExample/Pods-FabricExample.debug.xcconfig"; sourceTree = "<group>"; };
+		A61D45BF3509EB33570F1B29 /* Pods-FabricExample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FabricExample.debug.xcconfig"; path = "Target Support Files/Pods-FabricExample/Pods-FabricExample.debug.xcconfig"; sourceTree = "<group>"; };
+		DB04969345CB526151FFE3EE /* Pods-FabricExampleTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FabricExampleTests.release.xcconfig"; path = "Target Support Files/Pods-FabricExampleTests/Pods-FabricExampleTests.release.xcconfig"; sourceTree = "<group>"; };
+		E0EC3D229F0E7FC9C6E7101F /* Pods-FabricExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FabricExample.release.xcconfig"; path = "Target Support Files/Pods-FabricExample/Pods-FabricExample.release.xcconfig"; sourceTree = "<group>"; };
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
+		FF8D959348CB846E135D2FDA /* Pods-FabricExampleTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FabricExampleTests.debug.xcconfig"; path = "Target Support Files/Pods-FabricExampleTests/Pods-FabricExampleTests.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -61,7 +61,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				9431C8C4ED3457D596A01B6D /* libPods-FabricExample.a in Frameworks */,
+				E0C4BF4B755B737C4C5540FD /* libPods-FabricExample.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -69,7 +69,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				C6B1CAFF6291E45DDBE7E1F7 /* libPods-FabricExampleTests.a in Frameworks */,
+				1050F6737024FB405F115BFA /* libPods-FabricExampleTests.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -92,8 +92,8 @@
 			isa = PBXGroup;
 			children = (
 				ED297162215061F000B7C4FE /* JavaScriptCore.framework */,
-				AC66076F8C982497E228877B /* libPods-FabricExample.a */,
-				A00102112FA5D4913944E288 /* libPods-FabricExampleTests.a */,
+				241D7C6CA3A04635173C2709 /* libPods-FabricExample.a */,
+				41016FD6C289B5352D135325 /* libPods-FabricExampleTests.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -146,10 +146,10 @@
 		BBD78D7AC51CEA395F1C20DB /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				E224256D1CD024C67AF02169 /* Pods-FabricExample.debug.xcconfig */,
-				93C74A141660B02FBC0D26CB /* Pods-FabricExample.release.xcconfig */,
-				50CA7291BB5F88710E5BAE88 /* Pods-FabricExampleTests.debug.xcconfig */,
-				6990A9CF6077081C2F380E7F /* Pods-FabricExampleTests.release.xcconfig */,
+				A61D45BF3509EB33570F1B29 /* Pods-FabricExample.debug.xcconfig */,
+				E0EC3D229F0E7FC9C6E7101F /* Pods-FabricExample.release.xcconfig */,
+				FF8D959348CB846E135D2FDA /* Pods-FabricExampleTests.debug.xcconfig */,
+				DB04969345CB526151FFE3EE /* Pods-FabricExampleTests.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -161,7 +161,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = A1B2C3DF1E00000100A0A001 /* Build configuration list for PBXNativeTarget "FabricExampleTests" */;
 			buildPhases = (
-				0D7AD4DA365DFD3E06A79023 /* [CP] Check Pods Manifest.lock */,
+				4A3AF25A720C97D87B7410FF /* [CP] Check Pods Manifest.lock */,
 				A1B2C3DC1E00000100A0A001 /* Sources */,
 				A1B2C3D71E00000100A0A001 /* Frameworks */,
 				A1B2C3DB1E00000100A0A001 /* Resources */,
@@ -180,13 +180,13 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 13B07F931A680F5B00A75B9A /* Build configuration list for PBXNativeTarget "FabricExample" */;
 			buildPhases = (
-				C192B508C5C5D2D85F8F282E /* [CP] Check Pods Manifest.lock */,
+				F85574449E1B33AF7B6B126C /* [CP] Check Pods Manifest.lock */,
 				13B07F871A680F5B00A75B9A /* Sources */,
 				13B07F8C1A680F5B00A75B9A /* Frameworks */,
 				13B07F8E1A680F5B00A75B9A /* Resources */,
 				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
-				146CE481FF112E265208DDC2 /* [CP] Embed Pods Frameworks */,
-				378714097EB7CCCD0C39EB08 /* [CP] Copy Pods Resources */,
+				951253BBFB6CC71E820DCB80 /* [CP] Embed Pods Frameworks */,
+				D344E4DEBE37215FBF009C9D /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -270,7 +270,7 @@
 			shellPath = /bin/sh;
 			shellScript = "set -e\n\nWITH_ENVIRONMENT=\"$REACT_NATIVE_PATH/scripts/xcode/with-environment.sh\"\nREACT_NATIVE_XCODE=\"$REACT_NATIVE_PATH/scripts/react-native-xcode.sh\"\n\n/bin/sh -c \"$WITH_ENVIRONMENT $REACT_NATIVE_XCODE\"\n";
 		};
-		0D7AD4DA365DFD3E06A79023 /* [CP] Check Pods Manifest.lock */ = {
+		4A3AF25A720C97D87B7410FF /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -292,7 +292,7 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		146CE481FF112E265208DDC2 /* [CP] Embed Pods Frameworks */ = {
+		951253BBFB6CC71E820DCB80 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -309,7 +309,7 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-FabricExample/Pods-FabricExample-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		378714097EB7CCCD0C39EB08 /* [CP] Copy Pods Resources */ = {
+		D344E4DEBE37215FBF009C9D /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -326,7 +326,7 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-FabricExample/Pods-FabricExample-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		C192B508C5C5D2D85F8F282E /* [CP] Check Pods Manifest.lock */ = {
+		F85574449E1B33AF7B6B126C /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -386,13 +386,13 @@
 /* Begin XCBuildConfiguration section */
 		13B07F941A680F5B00A75B9A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = E224256D1CD024C67AF02169 /* Pods-FabricExample.debug.xcconfig */;
+			baseConfigurationReference = A61D45BF3509EB33570F1B29 /* Pods-FabricExample.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
-				DEVELOPMENT_TEAM = WC59N2X3FV;
+				DEVELOPMENT_TEAM = 852ZJU38RC;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = FabricExample/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
@@ -412,7 +412,7 @@
 					"-lc++",
 				);
 				PRESERVE_DEAD_CODE_INITS_AND_TERMS = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = "fdsfsdfsdcom-eseg3222233er.--PRODUCT-NAME-rfc1034identifier-";
+				PRODUCT_BUNDLE_IDENTIFIER = "fdsfsdfsdcom-eseg3222233e.--PRODUCT-NAME-rfc1034identifier-";
 				PRODUCT_NAME = FabricExample;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
@@ -425,13 +425,13 @@
 		};
 		13B07F951A680F5B00A75B9A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 93C74A141660B02FBC0D26CB /* Pods-FabricExample.release.xcconfig */;
+			baseConfigurationReference = E0EC3D229F0E7FC9C6E7101F /* Pods-FabricExample.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
-				DEVELOPMENT_TEAM = WC59N2X3FV;
+				DEVELOPMENT_TEAM = 852ZJU38RC;
 				INFOPLIST_FILE = FabricExample/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -450,7 +450,7 @@
 					"-lc++",
 				);
 				PRESERVE_DEAD_CODE_INITS_AND_TERMS = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = "fdsfsdfsdcom-eseg3222233er.--PRODUCT-NAME-rfc1034identifier-";
+				PRODUCT_BUNDLE_IDENTIFIER = "fdsfsdfsdcom-eseg3222233e.--PRODUCT-NAME-rfc1034identifier-";
 				PRODUCT_NAME = FabricExample;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
@@ -652,7 +652,7 @@
 		};
 		A1B2C3DD1E00000100A0A001 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 50CA7291BB5F88710E5BAE88 /* Pods-FabricExampleTests.debug.xcconfig */;
+			baseConfigurationReference = FF8D959348CB846E135D2FDA /* Pods-FabricExampleTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_ENABLE_MODULES = YES;
@@ -679,7 +679,7 @@
 		};
 		A1B2C3DE1E00000100A0A001 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 6990A9CF6077081C2F380E7F /* Pods-FabricExampleTests.release.xcconfig */;
+			baseConfigurationReference = DB04969345CB526151FFE3EE /* Pods-FabricExampleTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_ENABLE_MODULES = YES;

--- a/apps/fabric-example/ios/Podfile.lock
+++ b/apps/fabric-example/ios/Podfile.lock
@@ -1842,7 +1842,7 @@ PODS:
     - React-utils (= 0.85.0)
     - ReactNativeDependencies
   - ReactNativeDependencies (0.85.0)
-  - RNAudioAPI (0.13.0):
+  - RNAudioAPI (1.0.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1863,10 +1863,10 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-    - RNAudioAPI/audioapi (= 0.13.0)
+    - RNAudioAPI/audioapi (= 1.0.0)
     - RNWorklets
     - Yoga
-  - RNAudioAPI/audioapi (0.13.0):
+  - RNAudioAPI/audioapi (1.0.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1887,35 +1887,12 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-    - RNAudioAPI/audioapi/audioapi_dsp (= 0.13.0)
-    - RNAudioAPI/audioapi/ios (= 0.13.0)
-    - RNAudioAPI/audioapi/miniaudio_impl (= 0.13.0)
+    - RNAudioAPI/audioapi/audioapi_dsp (= 1.0.0)
+    - RNAudioAPI/audioapi/ios (= 1.0.0)
+    - RNAudioAPI/audioapi/miniaudio_impl (= 1.0.0)
     - RNWorklets
     - Yoga
-  - RNAudioAPI/audioapi/audioapi_dsp (0.13.0):
-    - hermes-engine
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-Core-prebuilt
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-ImageManager
-    - React-jsi
-    - React-NativeModulesApple
-    - React-RCTFabric
-    - React-renderercss
-    - React-rendererdebug
-    - React-utils
-    - ReactCodegen
-    - ReactCommon/turbomodule/bridging
-    - ReactCommon/turbomodule/core
-    - ReactNativeDependencies
-    - RNWorklets
-    - Yoga
-  - RNAudioAPI/audioapi/ios (0.13.0):
+  - RNAudioAPI/audioapi/audioapi_dsp (1.0.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1938,7 +1915,30 @@ PODS:
     - ReactNativeDependencies
     - RNWorklets
     - Yoga
-  - RNAudioAPI/audioapi/miniaudio_impl (0.13.0):
+  - RNAudioAPI/audioapi/ios (1.0.0):
+    - hermes-engine
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-Core-prebuilt
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-jsi
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-renderercss
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - ReactNativeDependencies
+    - RNWorklets
+    - Yoga
+  - RNAudioAPI/audioapi/miniaudio_impl (1.0.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2476,7 +2476,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   FBLazyVector: c00c20551d40126351a6783c47ce75f5b374851b
-  hermes-engine: 91023181d4bc5948b457de5314623fbfe4f8604e
+  hermes-engine: c399a2e224a0b13c589d76b4fc05e14bdd76fa88
   RCTDeprecation: 3bb167081b134461cfeb875ff7ae1945f8635257
   RCTRequired: 74839f55d5058a133a0bc4569b0afec750957f64
   RCTSwiftUI: 87a316382f3eab4dd13d2a0d0fd2adcce917361a
@@ -2485,7 +2485,7 @@ SPEC CHECKSUMS:
   React: 1b1536b9099195944034e65b1830f463caaa8390
   React-callinvoker: 6dff6d17d1d6cc8fdf85468a649bafed473c65f5
   React-Core: 00faa4d038298089a1d5a5b21dde8660c4f0820d
-  React-Core-prebuilt: a6d614de037caff7898424dfc22915ec792de921
+  React-Core-prebuilt: ab26be1216323aea7c76f96ca450bffa7bcd4a72
   React-CoreModules: a17807f849bfd86045b0b9a75ec8c19373b482f6
   React-cxxreact: c7b53ace5827be54048288bce5c55f337c41e95f
   React-debug: e1f00fcd2cef58a2897471a6d76a4ef5f5f90c74
@@ -2549,8 +2549,8 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 5787b37b8e2e51dfeab697ec031cc7c4080dcea2
   ReactCodegen: d07ee3c8db75b43d1cbe479ae6affebf9925c733
   ReactCommon: fe2a3af8975e63efa60f95fca8c34dc85deee360
-  ReactNativeDependencies: 4d5ce2683b6d74f7c686bf90a88c7d381295cf3c
-  RNAudioAPI: b689aba6e8b4e6ac85b7e4eb53ebb74a020fbed4
+  ReactNativeDependencies: 212738cc51e6c4cc34ee487890497d6f41979ec0
+  RNAudioAPI: 6b07e5393a8016de35ba8d2f8b010ce2d7e0c3fd
   RNGestureHandler: 187c5c7936abf427bc4d22d6c3b1ac80ad1f63c0
   RNReanimated: 64f4b3b33b48b19e0ba76a352571b52b1e931981
   RNScreens: 01b065ded2dfe7987bcce770ff3a196be417ff41

--- a/apps/fabric-example/ios/Podfile.lock
+++ b/apps/fabric-example/ios/Podfile.lock
@@ -2550,7 +2550,7 @@ SPEC CHECKSUMS:
   ReactCodegen: d07ee3c8db75b43d1cbe479ae6affebf9925c733
   ReactCommon: fe2a3af8975e63efa60f95fca8c34dc85deee360
   ReactNativeDependencies: 212738cc51e6c4cc34ee487890497d6f41979ec0
-  RNAudioAPI: 6b07e5393a8016de35ba8d2f8b010ce2d7e0c3fd
+  RNAudioAPI: 555be5f8e643f733db95096a9c6902e43bddec23
   RNGestureHandler: 187c5c7936abf427bc4d22d6c3b1ac80ad1f63c0
   RNReanimated: 64f4b3b33b48b19e0ba76a352571b52b1e931981
   RNScreens: 01b065ded2dfe7987bcce770ff3a196be417ff41

--- a/packages/react-native-audio-api/RNAudioAPI.podspec
+++ b/packages/react-native-audio-api/RNAudioAPI.podspec
@@ -75,6 +75,7 @@ Pod::Spec.new do |s|
   ffmpeg_dir = "$(PODS_ROOT)/#{$audio_api_config[:dynamic_frameworks_audio_api_dir]}/#{external_dir_relative}/ffmpeg_ios"
 
   ffmpeg_framework_names =  %w[libavcodec libavformat libavutil libswresample]
+  static_external_libs_names = %w[libopusfile libopus libogg libvorbis libvorbisenc libvorbisfile]
 
   # `prepare_command` hydrates binaries on a fresh `pod install` so CocoaPods can
   # register all vendored `.xcframework`s in `[CP] Copy XCFrameworks`. When `Pods/`
@@ -93,7 +94,7 @@ Pod::Spec.new do |s|
     download_output_files = []
 
     unless $RN_AUDIO_API_STATIC_EXTERNAL_LIBS_DISABLED
-      %w[libopusfile libopus libogg libvorbis libvorbisenc libvorbisfile].each do |lib|
+      static_external_libs_names.each do |lib|
         download_output_files << "#{lib_dir}/#{lib}.a"
       end
     end
@@ -175,14 +176,9 @@ Pod::Spec.new do |s|
     'OTHER_LDFLAGS' => %W[
       $(inherited)
     ]
-    .concat($RN_AUDIO_API_STATIC_EXTERNAL_LIBS_DISABLED ? [] : %W[
-      -force_load #{lib_dir}/libopusfile.a
-      -force_load #{lib_dir}/libopus.a
-      -force_load #{lib_dir}/libogg.a
-      -force_load #{lib_dir}/libvorbis.a
-      -force_load #{lib_dir}/libvorbisenc.a
-      -force_load #{lib_dir}/libvorbisfile.a
-    ])
+    .concat($RN_AUDIO_API_STATIC_EXTERNAL_LIBS_DISABLED ? [] : static_external_libs_names.flat_map { |lib|
+      ['-force_load', "#{lib_dir}/#{lib}.a"]
+    })
     .join(" "),
   }
   # Use install_modules_dependencies helper to install the dependencies if React Native version >=0.71.0.

--- a/packages/react-native-audio-api/RNAudioAPI.podspec
+++ b/packages/react-native-audio-api/RNAudioAPI.podspec
@@ -18,7 +18,7 @@ worklets_preprocessor_flag = worklets_enabled ? '-DRN_AUDIO_API_ENABLE_WORKLETS=
 ffmpeg_flag = $RN_AUDIO_API_FFMPEG_DISABLED ? '-DRN_AUDIO_API_FFMPEG_DISABLED=1' : ''
 static_external_libs_flag = $RN_AUDIO_API_STATIC_EXTERNAL_LIBS_DISABLED ? '-DRN_AUDIO_API_STATIC_EXTERNAL_LIBS_DISABLED=1 -DMA_NO_LIBOPUS=1 -DMA_NO_LIBVORBIS=1' : ''
 skip_ffmpeg_argument = $RN_AUDIO_API_FFMPEG_DISABLED ? 'skipffmpeg' : ''
-prepare_command_prefix = $RN_AUDIO_API_STATIC_EXTERNAL_LIBS_DISABLED ? 'DISABLE_AUDIOAPI_STATIC_EXTERNAL_LIBS=1 ' : ''
+download_script_env_prefix = $RN_AUDIO_API_STATIC_EXTERNAL_LIBS_DISABLED ? 'DISABLE_AUDIOAPI_STATIC_EXTERNAL_LIBS=1 ' : ''
 
 Pod::Spec.new do |s|
   s.name         = "RNAudioAPI"
@@ -67,18 +67,59 @@ Pod::Spec.new do |s|
 
   s.prepare_command = <<-CMD
     chmod +x scripts/download-prebuilt-binaries.sh
-    #{prepare_command_prefix}scripts/download-prebuilt-binaries.sh ios #{skip_ffmpeg_argument}
+    #{download_script_env_prefix}scripts/download-prebuilt-binaries.sh ios #{skip_ffmpeg_argument}
   CMD
 
   external_dir_relative = "common/cpp/audioapi/external"
   lib_dir = "$(PODS_ROOT)/#{$audio_api_config[:dynamic_frameworks_audio_api_dir]}/#{external_dir_relative}/$(PLATFORM_NAME)"
+  ffmpeg_dir = "$(PODS_ROOT)/#{$audio_api_config[:dynamic_frameworks_audio_api_dir]}/#{external_dir_relative}/ffmpeg_ios"
 
-  s.ios.vendored_frameworks = $RN_AUDIO_API_FFMPEG_DISABLED ? [] : [
-    'common/cpp/audioapi/external/ffmpeg_ios/libavcodec.xcframework',
-    'common/cpp/audioapi/external/ffmpeg_ios/libavformat.xcframework',
-    'common/cpp/audioapi/external/ffmpeg_ios/libavutil.xcframework',
-    'common/cpp/audioapi/external/ffmpeg_ios/libswresample.xcframework'
-  ]
+  ffmpeg_framework_names =  %w[libavcodec libavformat libavutil libswresample]
+
+  # `prepare_command` hydrates binaries on a fresh `pod install` so CocoaPods can
+  # register all vendored `.xcframework`s in `[CP] Copy XCFrameworks`. When `Pods/`
+  # is restored from cache while `node_modules/` is reinstalled, `prepare_command`
+  # does not re-run — the build-time phase below re-hydrates on every build.
+  #
+  # It must run at `:before_headers` so it lands ahead of CocoaPods' own
+  # `[CP] Copy XCFrameworks` phase, which consumes the FFmpeg xcframeworks. If it
+  # ran later (e.g. `:before_compile`, which is after Copy XCFrameworks), Xcode
+  # would reject the build when the xcframeworks are missing before we download.
+  #
+  # `output_files` declares everything the linker (`-force_load` static libs in
+  # `s.xcconfig`) and Copy XCFrameworks (FFmpeg) consume, so Xcode's build graph
+  # knows this phase produces them.
+  unless $RN_AUDIO_API_STATIC_EXTERNAL_LIBS_DISABLED && $RN_AUDIO_API_FFMPEG_DISABLED
+    download_output_files = []
+
+    unless $RN_AUDIO_API_STATIC_EXTERNAL_LIBS_DISABLED
+      %w[libopusfile libopus libogg libvorbis libvorbisenc libvorbisfile].each do |lib|
+        download_output_files << "#{lib_dir}/#{lib}.a"
+      end
+    end
+
+    unless $RN_AUDIO_API_FFMPEG_DISABLED
+      ffmpeg_framework_names.each do |framework|
+        download_output_files << "#{ffmpeg_dir}/#{framework}.xcframework"
+      end
+    end
+
+    s.script_phase = {
+      :name => 'Download RNAudioAPI prebuilt binaries',
+      :execution_position => :before_headers,
+      :always_out_of_date => '1',
+      :output_files => download_output_files,
+      :script => <<-SCRIPT
+        cd "$PODS_TARGET_SRCROOT"
+        chmod +x scripts/download-prebuilt-binaries.sh
+        #{download_script_env_prefix}scripts/download-prebuilt-binaries.sh ios #{skip_ffmpeg_argument}
+      SCRIPT
+    }
+  end
+
+  s.ios.vendored_frameworks = $RN_AUDIO_API_FFMPEG_DISABLED ? [] : ffmpeg_framework_names.map { |framework|
+    "common/cpp/audioapi/external/ffmpeg_ios/#{framework}.xcframework"
+  }
 
   s.pod_target_xcconfig = {
     "USE_HEADERMAP" => "YES",

--- a/packages/react-native-audio-api/common/cpp/audioapi/HostObjects/AudioNodeHostObject.h
+++ b/packages/react-native-audio-api/common/cpp/audioapi/HostObjects/AudioNodeHostObject.h
@@ -5,7 +5,7 @@
 #include <audioapi/core/utils/Constants.h>
 #include <audioapi/core/utils/graph/Graph.h>
 #include <audioapi/core/utils/graph/HostNode.h>
-#include <audioapi/jsi/JsiHostObject.h>
+#include <audioapi/jsi/HostObject.h>
 #include <audioapi/types/NodeOptions.h>
 
 #include <jsi/jsi.h>
@@ -17,7 +17,7 @@ using namespace facebook;
 
 class AudioNode;
 
-class AudioNodeHostObject : public JsiHostObject, public utils::graph::HostNode {
+class AudioNodeHostObject : public HostObject, public utils::graph::HostNode {
  public:
   explicit AudioNodeHostObject(
       const std::shared_ptr<utils::graph::Graph> &graph,

--- a/packages/react-native-audio-api/common/cpp/audioapi/HostObjects/AudioParamHostObject.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/HostObjects/AudioParamHostObject.cpp
@@ -2,7 +2,7 @@
 #include <audioapi/core/AudioParam.h>
 #include <audioapi/core/utils/graph/BridgeNode.h>
 #include <audioapi/core/utils/param/ParamEvent.h>
-#include <audioapi/jsi/JsiHostObject.h>
+#include <audioapi/jsi/HostObject.h>
 #include <audioapi/utils/AudioArray.hpp>
 #include <memory>
 #include <string>

--- a/packages/react-native-audio-api/common/cpp/audioapi/HostObjects/AudioParamHostObject.h
+++ b/packages/react-native-audio-api/common/cpp/audioapi/HostObjects/AudioParamHostObject.h
@@ -3,7 +3,7 @@
 #include <audioapi/core/utils/Constants.h>
 #include <audioapi/core/utils/graph/HostNode.h>
 #include <audioapi/core/utils/param/ParamControlQueue.h>
-#include <audioapi/jsi/JsiHostObject.h>
+#include <audioapi/jsi/HostObject.h>
 #include <audioapi/utils/Result.hpp>
 #include <jsi/jsi.h>
 #include <cstddef>
@@ -26,7 +26,7 @@ inline constexpr size_t kAudioParamBytes = 2 * RENDER_QUANTUM_SIZE * sizeof(floa
 /// to this param connect to the bridge node (source → bridge).
 ///
 /// When destroyed, the BridgeNode is removed from the graph.
-class AudioParamHostObject : public JsiHostObject {
+class AudioParamHostObject : public HostObject {
  public:
   using HNode = utils::graph::HostGraph::Node;
 

--- a/packages/react-native-audio-api/common/cpp/audioapi/HostObjects/BaseAudioContextHostObject.h
+++ b/packages/react-native-audio-api/common/cpp/audioapi/HostObjects/BaseAudioContextHostObject.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <audioapi/jsi/JsiHostObject.h>
+#include <audioapi/jsi/HostObject.h>
 #include <audioapi/jsi/JsiPromise.h>
 
 #include <jsi/jsi.h>
@@ -13,7 +13,7 @@ using namespace facebook;
 class BaseAudioContext;
 class AudioDestinationNodeHostObject;
 
-class BaseAudioContextHostObject : public JsiHostObject {
+class BaseAudioContextHostObject : public HostObject {
  public:
   explicit BaseAudioContextHostObject(
       const std::shared_ptr<BaseAudioContext> &context,

--- a/packages/react-native-audio-api/common/cpp/audioapi/HostObjects/events/AudioEventHandlerRegistryHostObject.h
+++ b/packages/react-native-audio-api/common/cpp/audioapi/HostObjects/events/AudioEventHandlerRegistryHostObject.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <audioapi/jsi/JsiHostObject.h>
+#include <audioapi/jsi/HostObject.h>
 
 #include <ReactCommon/CallInvoker.h>
 #include <jsi/jsi.h>
@@ -11,7 +11,7 @@ using namespace facebook;
 
 class AudioEventHandlerRegistry;
 
-class AudioEventHandlerRegistryHostObject : public JsiHostObject {
+class AudioEventHandlerRegistryHostObject : public HostObject {
  public:
   explicit AudioEventHandlerRegistryHostObject(
       const std::shared_ptr<AudioEventHandlerRegistry> &eventHandlerRegistry);

--- a/packages/react-native-audio-api/common/cpp/audioapi/HostObjects/inputs/AudioRecorderHostObject.h
+++ b/packages/react-native-audio-api/common/cpp/audioapi/HostObjects/inputs/AudioRecorderHostObject.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <ReactCommon/CallInvoker.h>
-#include <audioapi/jsi/JsiHostObject.h>
+#include <audioapi/jsi/HostObject.h>
 #include <audioapi/jsi/JsiPromise.h>
 
 #include <memory>
@@ -12,7 +12,7 @@ using namespace facebook;
 class AudioRecorder;
 class AudioEventHandlerRegistry;
 
-class AudioRecorderHostObject : public JsiHostObject {
+class AudioRecorderHostObject : public HostObject {
  public:
   AudioRecorderHostObject(
       const std::shared_ptr<AudioEventHandlerRegistry> &audioEventHandlerRegistry,

--- a/packages/react-native-audio-api/common/cpp/audioapi/HostObjects/sources/AudioBufferHostObject.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/HostObjects/sources/AudioBufferHostObject.cpp
@@ -22,7 +22,7 @@ AudioBufferHostObject::AudioBufferHostObject(const std::shared_ptr<AudioBuffer> 
 }
 
 AudioBufferHostObject::AudioBufferHostObject(AudioBufferHostObject &&other) noexcept
-    : JsiHostObject(std::move(other)), audioBuffer_(std::move(other.audioBuffer_)) {}
+    : HostObject(std::move(other)), audioBuffer_(std::move(other.audioBuffer_)) {}
 
 JSI_PROPERTY_GETTER_IMPL(AudioBufferHostObject, sampleRate) {
   return {audioBuffer_->getSampleRate()};

--- a/packages/react-native-audio-api/common/cpp/audioapi/HostObjects/sources/AudioBufferHostObject.h
+++ b/packages/react-native-audio-api/common/cpp/audioapi/HostObjects/sources/AudioBufferHostObject.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <audioapi/jsi/JsiHostObject.h>
+#include <audioapi/jsi/HostObject.h>
 #include <audioapi/utils/AudioBuffer.hpp>
 
 #include <jsi/jsi.h>
@@ -11,7 +11,7 @@
 namespace audioapi {
 using namespace facebook;
 
-class AudioBufferHostObject : public JsiHostObject {
+class AudioBufferHostObject : public HostObject {
  public:
   std::shared_ptr<AudioBuffer> audioBuffer_;
 
@@ -21,7 +21,7 @@ class AudioBufferHostObject : public JsiHostObject {
   AudioBufferHostObject(AudioBufferHostObject &&other) noexcept;
   AudioBufferHostObject &operator=(AudioBufferHostObject &&other) noexcept {
     if (this != &other) {
-      JsiHostObject::operator=(std::move(other));
+      HostObject::operator=(std::move(other));
       audioBuffer_ = std::move(other.audioBuffer_);
     }
     return *this;

--- a/packages/react-native-audio-api/common/cpp/audioapi/HostObjects/utils/AudioDecoderHostObject.h
+++ b/packages/react-native-audio-api/common/cpp/audioapi/HostObjects/utils/AudioDecoderHostObject.h
@@ -9,7 +9,7 @@
 namespace audioapi {
 using namespace facebook;
 
-class AudioDecoderHostObject : public JsiHostObject {
+class AudioDecoderHostObject : public HostObject {
  public:
   explicit AudioDecoderHostObject(
       jsi::Runtime *runtime,

--- a/packages/react-native-audio-api/common/cpp/audioapi/HostObjects/utils/AudioFileUtilsHostObject.h
+++ b/packages/react-native-audio-api/common/cpp/audioapi/HostObjects/utils/AudioFileUtilsHostObject.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <audioapi/jsi/JsiHostObject.h>
+#include <audioapi/jsi/HostObject.h>
 #include <audioapi/jsi/JsiPromise.h>
 
 #include <jsi/jsi.h>
@@ -9,7 +9,7 @@
 namespace audioapi {
 using namespace facebook;
 
-class AudioFileUtilsHostObject : public JsiHostObject {
+class AudioFileUtilsHostObject : public HostObject {
  public:
   explicit AudioFileUtilsHostObject(
       jsi::Runtime *runtime,

--- a/packages/react-native-audio-api/common/cpp/audioapi/HostObjects/utils/NodeOptionsParser.h
+++ b/packages/react-native-audio-api/common/cpp/audioapi/HostObjects/utils/NodeOptionsParser.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <audioapi/jsi/RuntimeLifecycleMonitor.h>
+#include <audioapi/jsi/RuntimeObserver.h>
 #include <jsi/jsi.h>
 #include <cmath>
 #include <cstddef>

--- a/packages/react-native-audio-api/common/cpp/audioapi/jsi/HostObject.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/jsi/HostObject.cpp
@@ -1,4 +1,4 @@
-#include <audioapi/jsi/JsiHostObject.h>
+#include <audioapi/jsi/HostObject.h>
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -12,19 +12,18 @@ namespace audioapi {
 
 #if JSI_DEBUG_ALLOCATIONS
 int objCounter = 0;
-std::vector<JsiHostObject *> objects;
+std::vector<HostObject *> objects;
 #endif
 
-JsiHostObject::JsiHostObject() {
+HostObject::HostObject() {
   getters_ = std::make_unique<
-      std::unordered_map<std::string, jsi::Value (JsiHostObject::*)(jsi::Runtime &)>>();
+      std::unordered_map<std::string, jsi::Value (HostObject::*)(jsi::Runtime &)>>();
   functions_ = std::make_unique<std::unordered_map<
       std::string,
-      jsi::Value (JsiHostObject::*)(
+      jsi::Value (HostObject::*)(
           jsi::Runtime &, const jsi::Value &, const jsi::Value *, size_t)>>();
-  setters_ = std::make_unique<std::unordered_map<
-      std::string,
-      void (JsiHostObject::*)(jsi::Runtime &, const jsi::Value &)>>();
+  setters_ = std::make_unique<
+      std::unordered_map<std::string, void (HostObject::*)(jsi::Runtime &, const jsi::Value &)>>();
 
 #if JSI_DEBUG_ALLOCATIONS
   objects.push_back(this);
@@ -32,7 +31,7 @@ JsiHostObject::JsiHostObject() {
 #endif
 }
 
-JsiHostObject::JsiHostObject(JsiHostObject &&other) noexcept
+HostObject::HostObject(HostObject &&other) noexcept
     : getters_(std::move(other.getters_)),
       functions_(std::move(other.functions_)),
       setters_(std::move(other.setters_)) {
@@ -45,7 +44,7 @@ JsiHostObject::JsiHostObject(JsiHostObject &&other) noexcept
 #endif
 }
 
-JsiHostObject &JsiHostObject::operator=(JsiHostObject &&other) noexcept {
+HostObject &HostObject::operator=(HostObject &&other) noexcept {
   if (this != &other) {
     getters_ = std::move(other.getters_);
     functions_ = std::move(other.functions_);
@@ -62,7 +61,7 @@ JsiHostObject &JsiHostObject::operator=(JsiHostObject &&other) noexcept {
   return *this;
 }
 
-JsiHostObject::~JsiHostObject() {
+HostObject::~HostObject() {
 #if JSI_DEBUG_ALLOCATIONS
   auto it = std::find(objects.begin(), objects.end(), this);
   if (it != objects.end()) {
@@ -72,7 +71,7 @@ JsiHostObject::~JsiHostObject() {
 #endif
 }
 
-std::vector<jsi::PropNameID> JsiHostObject::getPropertyNames(jsi::Runtime &rt) {
+std::vector<jsi::PropNameID> HostObject::getPropertyNames(jsi::Runtime &rt) {
   std::vector<jsi::PropNameID> propertyNames;
   propertyNames.reserve(getters_->size() + functions_->size() + setters_->size());
 
@@ -91,7 +90,7 @@ std::vector<jsi::PropNameID> JsiHostObject::getPropertyNames(jsi::Runtime &rt) {
   return propertyNames;
 }
 
-jsi::Value JsiHostObject::get(jsi::Runtime &runtime, const jsi::PropNameID &name) {
+jsi::Value HostObject::get(jsi::Runtime &runtime, const jsi::PropNameID &name) {
   auto nameAsString = name.utf8(runtime);
   auto &hostFunctionCache = hostFunctionCache_.get(runtime);
 
@@ -111,7 +110,7 @@ jsi::Value JsiHostObject::get(jsi::Runtime &runtime, const jsi::PropNameID &name
   if (function != functions_->end()) {
     auto dispatcher = std::bind(
         function->second,
-        reinterpret_cast<JsiHostObject *>(this),
+        reinterpret_cast<HostObject *>(this),
         std::placeholders::_1,
         std::placeholders::_2,
         std::placeholders::_3,
@@ -125,10 +124,7 @@ jsi::Value JsiHostObject::get(jsi::Runtime &runtime, const jsi::PropNameID &name
   return jsi::Value::undefined();
 }
 
-void JsiHostObject::set(
-    jsi::Runtime &runtime,
-    const jsi::PropNameID &name,
-    const jsi::Value &value) {
+void HostObject::set(jsi::Runtime &runtime, const jsi::PropNameID &name, const jsi::Value &value) {
   auto nameAsString = name.utf8(runtime);
 
   auto setter = setters_->find(nameAsString);

--- a/packages/react-native-audio-api/common/cpp/audioapi/jsi/HostObject.h
+++ b/packages/react-native-audio-api/common/cpp/audioapi/jsi/HostObject.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <audioapi/jsi/RuntimeAwareCache.h>
+#include <audioapi/jsi/RuntimeInstanceCache.h>
 
 #include <jsi/jsi.h>
 #include <map>
@@ -19,7 +19,7 @@
 #define JSI_EXPORT_FUNCTION(CLASS, FUNCTION) \
   std::make_pair( \
       std::string(#FUNCTION), \
-      static_cast<jsi::Value (JsiHostObject::*)( \
+      static_cast<jsi::Value (HostObject::*)( \
           jsi::Runtime &, const jsi::Value &, const jsi::Value *, size_t)>(&CLASS::FUNCTION))
 
 #define JSI_PROPERTY_GETTER_DECL(name) jsi::Value name(jsi::Runtime &runtime)
@@ -27,7 +27,7 @@
 #define JSI_EXPORT_PROPERTY_GETTER(CLASS, FUNCTION) \
   std::make_pair( \
       std::string(#FUNCTION), \
-      static_cast<jsi::Value (JsiHostObject::*)(jsi::Runtime &)>(&CLASS::FUNCTION))
+      static_cast<jsi::Value (HostObject::*)(jsi::Runtime &)>(&CLASS::FUNCTION))
 
 #define JSI_PROPERTY_SETTER_DECL(name) void name(jsi::Runtime &runtime, const jsi::Value &value)
 #define JSI_PROPERTY_SETTER_IMPL(CLASS, name) \
@@ -35,20 +35,20 @@
 #define JSI_EXPORT_PROPERTY_SETTER(CLASS, FUNCTION) \
   std::make_pair( \
       std::string(#FUNCTION), \
-      static_cast<void (JsiHostObject::*)(jsi::Runtime &, const jsi::Value &)>(&CLASS::FUNCTION))
+      static_cast<void (HostObject::*)(jsi::Runtime &, const jsi::Value &)>(&CLASS::FUNCTION))
 
 namespace audioapi {
 
 using namespace facebook;
 
-class JsiHostObject : public jsi::HostObject {
+class HostObject : public jsi::HostObject {
  public:
-  JsiHostObject();
-  JsiHostObject(const JsiHostObject &) = delete;
-  JsiHostObject &operator=(const JsiHostObject &) = delete;
-  JsiHostObject(JsiHostObject &&) noexcept;
-  JsiHostObject &operator=(JsiHostObject &&other) noexcept;
-  ~JsiHostObject() override;
+  HostObject();
+  HostObject(const HostObject &) = delete;
+  HostObject &operator=(const HostObject &) = delete;
+  HostObject(HostObject &&) noexcept;
+  HostObject &operator=(HostObject &&other) noexcept;
+  ~HostObject() override;
 
   std::vector<jsi::PropNameID> getPropertyNames(jsi::Runtime &rt) override;
 
@@ -72,21 +72,20 @@ class JsiHostObject : public jsi::HostObject {
   }
 
  protected:
-  std::unique_ptr<std::unordered_map<std::string, jsi::Value (JsiHostObject::*)(jsi::Runtime &)>>
+  std::unique_ptr<std::unordered_map<std::string, jsi::Value (HostObject::*)(jsi::Runtime &)>>
       getters_;
 
   std::unique_ptr<std::unordered_map<
       std::string,
-      jsi::Value (
-          JsiHostObject::*)(jsi::Runtime &, const jsi::Value &, const jsi::Value *, size_t)>>
+      jsi::Value (HostObject::*)(jsi::Runtime &, const jsi::Value &, const jsi::Value *, size_t)>>
       functions_;
 
   std::unique_ptr<
-      std::unordered_map<std::string, void (JsiHostObject::*)(jsi::Runtime &, const jsi::Value &)>>
+      std::unordered_map<std::string, void (HostObject::*)(jsi::Runtime &, const jsi::Value &)>>
       setters_;
 
  private:
-  RuntimeAwareCache<std::map<std::string, jsi::Function>> hostFunctionCache_;
+  RuntimeInstanceCache<std::map<std::string, jsi::Function>> hostFunctionCache_;
 };
 
 } // namespace audioapi

--- a/packages/react-native-audio-api/common/cpp/audioapi/jsi/RuntimeInstanceCache.h
+++ b/packages/react-native-audio-api/common/cpp/audioapi/jsi/RuntimeInstanceCache.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <audioapi/jsi/RuntimeLifecycleMonitor.h>
+#include <audioapi/jsi/RuntimeObserver.h>
 
 #include <jsi/jsi.h>
 #include <unordered_map>
@@ -21,17 +21,17 @@ using namespace facebook;
  * deleted is the root cause of that crash).
  */
 template <typename T>
-class RuntimeAwareCache : public RuntimeLifecycleListener {
+class RuntimeInstanceCache : public RuntimeObserverListener {
  public:
   void onRuntimeDestroyed(jsi::Runtime *rt) override {
     // A runtime has been destroyed, so destroy the related cache.
     runtimeCaches_.erase(rt);
   }
 
-  ~RuntimeAwareCache() override {
+  ~RuntimeInstanceCache() override {
     for (auto &cache : runtimeCaches_) {
       // remove all `onRuntimeDestroyed` listeners.
-      RuntimeLifecycleMonitor::removeListener(*cache.first, this);
+      RuntimeObserver::removeListener(*cache.first, this);
     }
   }
 
@@ -40,7 +40,7 @@ class RuntimeAwareCache : public RuntimeLifecycleListener {
       // This is the first time this Runtime has been accessed.
       // We set up a `onRuntimeDestroyed` listener for it and
       // initialize the cache map.
-      RuntimeLifecycleMonitor::addListener(rt, this);
+      RuntimeObserver::addListener(rt, this);
 
       T cache;
       runtimeCaches_.emplace(&rt, std::move(cache));

--- a/packages/react-native-audio-api/common/cpp/audioapi/jsi/RuntimeObserver.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/jsi/RuntimeObserver.cpp
@@ -1,4 +1,4 @@
-#include <audioapi/jsi/RuntimeLifecycleMonitor.h>
+#include <audioapi/jsi/RuntimeObserver.h>
 #include <memory>
 #include <mutex>
 #include <unordered_map>
@@ -7,14 +7,14 @@
 
 namespace audioapi {
 
-static std::unordered_map<jsi::Runtime *, std::unordered_set<RuntimeLifecycleListener *>> listeners;
+static std::unordered_map<jsi::Runtime *, std::unordered_set<RuntimeObserverListener *>> listeners;
 static std::mutex listenersMutex;
 
-struct RuntimeLifecycleMonitorObject : public jsi::HostObject {
+struct RuntimeObserverObject : public jsi::HostObject {
   jsi::Runtime *rt_;
-  explicit RuntimeLifecycleMonitorObject(jsi::Runtime *rt) : rt_(rt) {}
-  ~RuntimeLifecycleMonitorObject() override {
-    std::unordered_set<RuntimeLifecycleListener *> toNotify;
+  explicit RuntimeObserverObject(jsi::Runtime *rt) : rt_(rt) {}
+  ~RuntimeObserverObject() override {
+    std::unordered_set<RuntimeObserverListener *> toNotify;
     {
       std::scoped_lock lock(listenersMutex);
       auto listenersSet = listeners.find(rt_);
@@ -30,7 +30,7 @@ struct RuntimeLifecycleMonitorObject : public jsi::HostObject {
   }
 };
 
-void RuntimeLifecycleMonitor::addListener(jsi::Runtime &rt, RuntimeLifecycleListener *listener) {
+void RuntimeObserver::addListener(jsi::Runtime &rt, RuntimeObserverListener *listener) {
   std::scoped_lock lock(listenersMutex);
   auto listenersSet = listeners.find(&rt);
   if (listenersSet == listeners.end()) {
@@ -40,10 +40,9 @@ void RuntimeLifecycleMonitor::addListener(jsi::Runtime &rt, RuntimeLifecycleList
     // runtime's global object.
     rt.global().setProperty(
         rt,
-        "__rnaudioapi_runtime_lifecycle_monitor",
-        jsi::Object::createFromHostObject(
-            rt, std::make_shared<RuntimeLifecycleMonitorObject>(&rt)));
-    std::unordered_set<RuntimeLifecycleListener *> newSet;
+        "__rnaudioapi_runtime_observer",
+        jsi::Object::createFromHostObject(rt, std::make_shared<RuntimeObserverObject>(&rt)));
+    std::unordered_set<RuntimeObserverListener *> newSet;
     newSet.insert(listener);
     listeners.emplace(&rt, std::move(newSet));
   } else {
@@ -51,7 +50,7 @@ void RuntimeLifecycleMonitor::addListener(jsi::Runtime &rt, RuntimeLifecycleList
   }
 }
 
-void RuntimeLifecycleMonitor::removeListener(jsi::Runtime &rt, RuntimeLifecycleListener *listener) {
+void RuntimeObserver::removeListener(jsi::Runtime &rt, RuntimeObserverListener *listener) {
   std::scoped_lock lock(listenersMutex);
   auto listenersSet = listeners.find(&rt);
   if (listenersSet == listeners.end()) {

--- a/packages/react-native-audio-api/common/cpp/audioapi/jsi/RuntimeObserver.h
+++ b/packages/react-native-audio-api/common/cpp/audioapi/jsi/RuntimeObserver.h
@@ -10,8 +10,8 @@ using namespace facebook;
  * Listener interface that allows for getting notified when a jsi::Runtime
  * instance is destroyed.
  */
-struct RuntimeLifecycleListener {
-  virtual ~RuntimeLifecycleListener() = default;
+struct RuntimeObserverListener {
+  virtual ~RuntimeObserverListener() = default;
   virtual void onRuntimeDestroyed(jsi::Runtime *) = 0;
 };
 
@@ -21,9 +21,9 @@ struct RuntimeLifecycleListener {
  * cleanup any data that references a given jsi::Runtime instance before it gets
  * destroyed.
  */
-struct RuntimeLifecycleMonitor {
-  static void addListener(jsi::Runtime &rt, RuntimeLifecycleListener *listener);
-  static void removeListener(jsi::Runtime &rt, RuntimeLifecycleListener *listener);
+struct RuntimeObserver {
+  static void addListener(jsi::Runtime &rt, RuntimeObserverListener *listener);
+  static void removeListener(jsi::Runtime &rt, RuntimeObserverListener *listener);
 };
 
 } // namespace audioapi

--- a/packages/react-native-audio-api/common/cpp/audioapi/utils/AudioFileProperties.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/utils/AudioFileProperties.cpp
@@ -1,6 +1,6 @@
 #include <audioapi/utils/AudioFileProperties.h>
 
-#include <audioapi/jsi/JsiHostObject.h>
+#include <audioapi/jsi/HostObject.h>
 #include <jsi/jsi.h>
 #include <memory>
 #include <string>

--- a/packages/react-native-audio-api/scripts/download-prebuilt-binaries.sh
+++ b/packages/react-native-audio-api/scripts/download-prebuilt-binaries.sh
@@ -13,6 +13,32 @@ IOS_DOWNLOAD_NAMES=(
     "iphonesimulator.zip"
     "macosx.zip"
 )
+STATIC_LIB_NAMES=(
+    "libopusfile.a"
+    "libopus.a"
+    "libogg.a"
+    "libvorbis.a"
+    "libvorbisenc.a"
+    "libvorbisfile.a"
+)
+FFMPEG_IOS_FRAMEWORKS=(
+    "libavcodec.xcframework"
+    "libavformat.xcframework"
+    "libavutil.xcframework"
+    "libswresample.xcframework"
+)
+FFMPEG_ANDROID_SO_LIBS=(
+    "libavcodec.so"
+    "libavformat.so"
+    "libavutil.so"
+    "libswresample.so"
+)
+ANDROID_JNI_ABIS=(
+    "armeabi-v7a"
+    "arm64-v8a"
+    "x86_64"
+    "x86"
+)
 
 PLATFORM="$1"
 if [ "$PLATFORM" != "android" ] && [ "$PLATFORM" != "ios" ]; then
@@ -78,6 +104,56 @@ restore_versioned_framework_symlinks() {
     done
 }
 
+artifacts_present() {
+    local extracted_dir_name="$1"
+    local final_check_path="$2"
+    local abi
+    local lib
+    local framework
+    local so_lib
+
+    case "$extracted_dir_name" in
+        ffmpeg_ios)
+            for framework in "${FFMPEG_IOS_FRAMEWORKS[@]}"; do
+                if [ ! -d "${final_check_path}/${framework}" ]; then
+                    return 1
+                fi
+            done
+            ;;
+        jniLibs)
+            for abi in "${ANDROID_JNI_ABIS[@]}"; do
+                for so_lib in "${FFMPEG_ANDROID_SO_LIBS[@]}"; do
+                    if [ ! -f "${final_check_path}/${abi}/${so_lib}" ]; then
+                        return 1
+                    fi
+                done
+            done
+            ;;
+        android)
+            for abi in "${ANDROID_JNI_ABIS[@]}"; do
+                for lib in "${STATIC_LIB_NAMES[@]}"; do
+                    if [ ! -f "${final_check_path}/${abi}/${lib}" ]; then
+                        return 1
+                    fi
+                done
+            done
+            ;;
+        iphoneos|iphonesimulator|macosx)
+            for lib in "${STATIC_LIB_NAMES[@]}"; do
+                if [ ! -f "${final_check_path}/${lib}" ]; then
+                    return 1
+                fi
+            done
+            ;;
+        *)
+            [ -d "$final_check_path" ]
+            return
+            ;;
+    esac
+
+    return 0
+}
+
 for name in "${DOWNLOAD_NAMES[@]}"; do
     ARCH_URL="${MAIN_DOWNLOAD_URL}/${TAG}/${name}"
     ZIP_FILE_PATH="${TEMP_DOWNLOAD_DIR}/${name}"
@@ -101,11 +177,11 @@ for name in "${DOWNLOAD_NAMES[@]}"; do
     fi
     FINAL_CHECK_PATH="${OUTPUT_DIR}/${EXTRACTED_DIR_NAME}"
 
-    if [ -d "$FINAL_CHECK_PATH" ]; then
+    if artifacts_present "$EXTRACTED_DIR_NAME" "$FINAL_CHECK_PATH"; then
         continue
     fi
 
-    # If we are here, the directory does not exist, so we download and unzip.
+    # If we are here, the artifacts are missing, so we download and unzip.
     echo "Downloading from: $ARCH_URL"
     curl -fsSL "$ARCH_URL" -o "$ZIP_FILE_PATH"
 

--- a/packages/react-native-audio-api/scripts/download-prebuilt-binaries.sh
+++ b/packages/react-native-audio-api/scripts/download-prebuilt-binaries.sh
@@ -3,23 +3,33 @@
 
 MAIN_DOWNLOAD_URL="https://github.com/software-mansion-labs/rn-audio-libs/releases/download"
 TAG="v3.1.0"
-DOWNLOAD_NAMES=(
+ANDROID_DOWNLOAD_NAMES=(
     "android.zip"
+    "jniLibs.zip"
+)
+IOS_DOWNLOAD_NAMES=(
     "ffmpeg_ios.zip"
     "iphoneos.zip"
     "iphonesimulator.zip"
-    "jniLibs.zip"
     "macosx.zip"
 )
+
+PLATFORM="$1"
+if [ "$PLATFORM" != "android" ] && [ "$PLATFORM" != "ios" ]; then
+    echo "Error: platform argument required. Usage: $0 <android|ios> [skipffmpeg]"
+    exit 1
+fi
 
 # Use a temporary directory for downloads, ensuring it exists
 TEMP_DOWNLOAD_DIR="$(pwd)/audioapi-binaries-temp"
 mkdir -p "$TEMP_DOWNLOAD_DIR"
 
-if [ "$1" == "android" ]; then
+if [ "$PLATFORM" == "android" ]; then
     PROJECT_ROOT="$(pwd)/.."
+    DOWNLOAD_NAMES=("${ANDROID_DOWNLOAD_NAMES[@]}")
 else
     PROJECT_ROOT="$(pwd)"
+    DOWNLOAD_NAMES=("${IOS_DOWNLOAD_NAMES[@]}")
 fi
 
 if [ "$2" == "skipffmpeg" ]; then
@@ -113,6 +123,8 @@ for name in "${DOWNLOAD_NAMES[@]}"; do
 
 done
 
-restore_versioned_framework_symlinks
+if [ "$PLATFORM" == "ios" ]; then
+    restore_versioned_framework_symlinks
+fi
 
 rm -rf "$TEMP_DOWNLOAD_DIR"


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #1140 

## ⚠️ Breaking changes ⚠️

<!-- A brief description of the breaking changes -->

-

## Introduced changes

<!-- A brief description of the changes -->

- Split downloading static libs prebuilt for android and iOS
- Aligned downloading on iOS with Android approach. All prebuilts are downloaded in build time or on `pod install` if cache is invalid.
- Downloading script checks presence of all artifacts not only dirs as it used to be
- Renamed jsi utils classes

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added/Conducted relevant tests
- [ ] Performed self-review of the code
- [ ] Updated Web Audio API coverage
- [ ] Added support for web
- [ ] Updated old arch android spec file
