### PR TITLE
fix: `yarn wpt:report` now executes properly

### DIFF
--- a/packages/react-native-audio-api/wpt_tests/src/jsi_install.cpp
+++ b/packages/react-native-audio-api/wpt_tests/src/jsi_install.cpp
@@ -35,7 +35,6 @@ using facebook::jsi::Value;
 using Microsoft::NodeApiJsi::makeNodeApiJsiRuntime;
 using rnaudioapi::node::NodeJSRuntimeApi;
 using rnaudioapi::node::SyncCallInvoker;
-using RuntimeRegistry = ::RuntimeRegistry;
 
 struct JsiInstallState {
   std::unique_ptr<NodeJSRuntimeApi> jsRuntimeApi;
@@ -131,7 +130,6 @@ void installOfflineBindings(
             length,
             sampleRate,
             eventRegistry,
-            RuntimeRegistry{},
             &rt,
             callInvoker);
 
@@ -186,7 +184,6 @@ void installAudioContextBinding(
         auto hostObject = std::make_shared<AudioContextHostObject>(
             sampleRate,
             eventRegistry,
-            RuntimeRegistry{},
             &rt,
             callInvoker);
 

--- a/packages/react-native-audio-api/wpt_tests/wpt/skip-list.json
+++ b/packages/react-native-audio-api/wpt_tests/wpt/skip-list.json
@@ -20,6 +20,10 @@
     "reason": "hangs native offline renderer on large discrete-mixing graphs (engine bug, tracked separately)"
   },
   {
+    "pattern": "audiobuffersource-null.html",
+    "reason": "SIGSEGV in Node WPT runner when buffer is set then cleared to null before offline render (engine bug, tracked separately)"
+  },
+  {
     "pattern": "-crash.html",
     "reason": "browser crashtests without testharness stall the Node runner"
   },


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## ⚠️ Breaking changes ⚠️

<!-- A brief description of the breaking changes -->

-

## Introduced changes

<!-- A brief description of the changes -->

* Removed nonexistent `RuntimieRegistry` from `jsi_install.cpp`
* Skipping `audiobuffersource-null.html` WPT test due to a SIGSEGV crashing the testing process.

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added/Conducted relevant tests
- [ ] Performed self-review of the code
- [ ] Updated Web Audio API coverage
- [ ] Added support for web
- [ ] Updated old arch android spec file
