### PR TITLE
chore: exclude wpt tests

### DIFF
--- a/packages/react-native-audio-api/package.json
+++ b/packages/react-native-audio-api/package.json
@@ -22,7 +22,6 @@
   },
   "files": [
     "src/",
-    "wpt_tests/",
     "development/react/",
     "mock/",
     "lib/",

--- a/packages/react-native-audio-api/package.json
+++ b/packages/react-native-audio-api/package.json
@@ -46,7 +46,7 @@
     "!**/__mocks__",
     "!**/.*",
     "!**/node_modules",
-    "!common/cpp/cursor",
+    "!common/cpp/clangd",
     "!common/cpp/test",
     "scripts/setup-rn-audio-api-web.js",
     "scripts/rnaa_utils.rb",


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## ⚠️ Breaking changes ⚠️

<!-- A brief description of the breaking changes -->

- N/A

## Introduced changes

<!-- A brief description of the changes -->

- removed `wpt_tests` and `clangd` directories from `package.json` whitelist as it makes little to no sense to ship them with the library

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added/Conducted relevant tests
- [x] Performed self-review of the code
- [x] Updated Web Audio API coverage
- [x] Added support for web
- [x] Updated old arch android spec file
