### PR TITLE
Feat/rnaa 501 audio player common interface

### DIFF
--- a/.claude/skills/thread-safety-itc/SKILL.md
+++ b/.claude/skills/thread-safety-itc/SKILL.md
@@ -165,8 +165,6 @@ On Android, `AudioPlayer::onErrorAfterClose` also takes `driverMutex_` because O
 
 **Live `AudioContext` render quiescence:** `currentRenders_` on `AudioContext` is incremented at the start of each platform I/O callback (`IOSAudioPlayer::deliverOutputBuffers` / `AudioPlayer::onAudioReady`) via a reference passed in `initialize()`, and decremented when the callback returns (RAII scope). `suspend()` and `close()` call `waitForRenderQuiescence()` (under `driverMutex_`) before `processAudioEvents()` / `cleanup()`. Platform drivers share the `CommonPlayer` abstract base (`common/cpp/audioapi/core/CommonPlayer.h`).
 
-**Player vs recorder threads:** Empirically, playback and recording callbacks run on **different** threads on both platforms (iOS: `AVAudioSourceNode` vs `AVAudioSinkNode` under one `AVAudioEngine`; Android: separate Oboe output vs input streams). Do not assume shared mutable state is single-threaded between player and recorder.
-
 ---
 
 ## Common Mistakes

--- a/.claude/skills/thread-safety-itc/SKILL.md
+++ b/.claude/skills/thread-safety-itc/SKILL.md
@@ -163,7 +163,9 @@ Control-plane synchronization uses two layers — both are non-recursive `std::m
 
 On Android, `AudioPlayer::onErrorAfterClose` also takes `driverMutex_` because Oboe error callbacks bypass `AudioContext`.
 
-**Live `AudioContext` render quiescence:** `currentRenders_` on `AudioContext` is incremented at the start of each platform I/O callback (`IOSAudioPlayer::deliverOutputBuffers` / `AudioPlayer::onAudioReady`) via a reference passed in `initialize()`, and decremented when the callback returns (RAII scope). `suspend()` and `close()` call `waitForRenderQuiescence()` (under `driverMutex_`) before `processAudioEvents()` / `cleanup()`.
+**Live `AudioContext` render quiescence:** `currentRenders_` on `AudioContext` is incremented at the start of each platform I/O callback (`IOSAudioPlayer::deliverOutputBuffers` / `AudioPlayer::onAudioReady`) via a reference passed in `initialize()`, and decremented when the callback returns (RAII scope). `suspend()` and `close()` call `waitForRenderQuiescence()` (under `driverMutex_`) before `processAudioEvents()` / `cleanup()`. Platform drivers share the `CommonPlayer` abstract base (`common/cpp/audioapi/core/CommonPlayer.h`).
+
+**Player vs recorder threads:** Empirically, playback and recording callbacks run on **different** threads on both platforms (iOS: `AVAudioSourceNode` vs `AVAudioSinkNode` under one `AVAudioEngine`; Android: separate Oboe output vs input streams). Do not assume shared mutable state is single-threaded between player and recorder.
 
 ---
 

--- a/apps/fabric-example/ios/FabricExampleTests/AudioPlayerTests.mm
+++ b/apps/fabric-example/ios/FabricExampleTests/AudioPlayerTests.mm
@@ -1,6 +1,7 @@
 #import <AudioToolbox/AudioServices.h>
 #import <XCTest/XCTest.h>
 
+#import <audioapi/core/CommonPlayer.h>
 #import <audioapi/core/utils/Constants.h>
 #import <audioapi/ios/core/NativeAudioPlayer.h>
 #import <audioapi/ios/system/AudioEngine.h>
@@ -18,22 +19,22 @@ using namespace audioapi;
 
 namespace audioapi {
 
-class IOSAudioPlayer {
+class IOSAudioPlayer : public CommonPlayer {
  public:
   IOSAudioPlayer(
       const std::function<void(DSPAudioBuffer *, int)> &renderAudio,
       float sampleRate,
       int channelCount,
       std::atomic<uint32_t> &currentRenders);
-  ~IOSAudioPlayer();
+  ~IOSAudioPlayer() override;
 
-  bool start();
-  void stop();
-  bool resume();
-  void suspend();
-  void cleanup();
+  bool start() override;
+  void stop() override;
+  bool resume() override;
+  void suspend() override;
+  void cleanup() override;
 
-  bool isRunning() const;
+  [[nodiscard]] bool isRunning() const override;
 
  protected:
   std::shared_ptr<DSPAudioBuffer> audioBuffer_;

--- a/packages/react-native-audio-api/android/src/main/cpp/audioapi/android/core/AudioPlayer.cpp
+++ b/packages/react-native-audio-api/android/src/main/cpp/audioapi/android/core/AudioPlayer.cpp
@@ -55,6 +55,12 @@ bool AudioPlayer::openAudioStream() {
 }
 
 bool AudioPlayer::start() {
+  if (!isInitialized_.load(std::memory_order_acquire)) {
+    if (!openAudioStream()) {
+      return false;
+    }
+  }
+
   if (mStream_ != nullptr) {
     auto result = mStream_->requestStart() == oboe::Result::OK;
     isRunning_.store(result, std::memory_order_release);

--- a/packages/react-native-audio-api/android/src/main/cpp/audioapi/android/core/AudioPlayer.h
+++ b/packages/react-native-audio-api/android/src/main/cpp/audioapi/android/core/AudioPlayer.h
@@ -7,6 +7,7 @@
 #include <mutex>
 
 #include <audioapi/android/core/NativeAudioPlayer.hpp>
+#include <audioapi/core/CommonPlayer.h>
 #include <audioapi/utils/AudioBuffer.hpp>
 
 namespace audioapi {
@@ -15,11 +16,11 @@ using namespace oboe;
 
 class AudioContext;
 
-class AudioPlayer : public AudioStreamDataCallback,
+class AudioPlayer : public CommonPlayer,
+                    public AudioStreamDataCallback,
                     public AudioStreamErrorCallback,
                     public std::enable_shared_from_this<AudioPlayer> {
  public:
-  friend class AudioContext;
   AudioPlayer(
       const std::function<void(DSPAudioBuffer *, int)> &renderAudio,
       float sampleRate,
@@ -33,13 +34,13 @@ class AudioPlayer : public AudioStreamDataCallback,
     cleanup();
   }
 
-  bool start();
-  void stop();
-  bool resume();
-  void suspend();
-  void cleanup();
+  bool start() override;
+  void stop() override;
+  bool resume() override;
+  void suspend() override;
+  void cleanup() override;
 
-  [[nodiscard]] bool isRunning() const;
+  [[nodiscard]] bool isRunning() const override;
 
   DataCallbackResult onAudioReady(AudioStream *oboeStream, void *audioData, int32_t numFrames)
       override;

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/AudioContext.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/AudioContext.cpp
@@ -38,7 +38,6 @@ void AudioContext::initialize(const AudioDestinationNode *destination) {
       &driverMutex_,
       std::static_pointer_cast<AudioContext>(shared_from_this()),
       currentRenders_);
-  audioPlayer_->openAudioStream();
 #else
   audioPlayer_ = std::make_shared<IOSAudioPlayer>(
       [this](DSPAudioBuffer *buf, int n) { processGraph(buf, n); },

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/AudioContext.h
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/AudioContext.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <audioapi/core/BaseAudioContext.h>
+#include <audioapi/core/CommonPlayer.h>
 #include <audioapi/utils/AudioBuffer.hpp>
 #include <audioapi/utils/Macros.h>
 
@@ -9,13 +10,6 @@
 #include <memory>
 
 namespace audioapi {
-#ifdef RN_AUDIO_API_NODE
-class NodeAudioPlayer;
-#elif defined(ANDROID)
-class AudioPlayer;
-#else
-class IOSAudioPlayer;
-#endif
 
 class AudioContext : public BaseAudioContext {
  public:
@@ -36,13 +30,7 @@ class AudioContext : public BaseAudioContext {
   void initialize(const AudioDestinationNode *destination) final;
 
  private:
-#ifdef RN_AUDIO_API_NODE
-  std::shared_ptr<NodeAudioPlayer> audioPlayer_;
-#elif defined(ANDROID)
-  std::shared_ptr<AudioPlayer> audioPlayer_;
-#else
-  std::shared_ptr<IOSAudioPlayer> audioPlayer_;
-#endif
+  std::shared_ptr<CommonPlayer> audioPlayer_;
   std::atomic<bool> isInitialized_{false};
   /// Audio I/O callback thread increments around each platform render callback;
   /// control thread waits on suspend/close.

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/CommonPlayer.h
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/CommonPlayer.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <audioapi/utils/Macros.h>
+
+namespace audioapi {
+
+class CommonPlayer {
+ public:
+  CommonPlayer() = default;
+  DELETE_COPY_AND_MOVE(CommonPlayer);
+  virtual ~CommonPlayer() = default;
+
+  virtual bool start() = 0;
+  virtual void stop() = 0;
+  virtual bool resume() = 0;
+  virtual void suspend() = 0;
+  virtual void cleanup() = 0;
+
+  [[nodiscard]] virtual bool isRunning() const = 0;
+};
+
+} // namespace audioapi

--- a/packages/react-native-audio-api/ios/audioapi/ios/core/IOSAudioPlayer.h
+++ b/packages/react-native-audio-api/ios/audioapi/ios/core/IOSAudioPlayer.h
@@ -7,6 +7,7 @@ typedef struct objc_object NativeAudioPlayer;
 typedef struct objc_object AudioBufferList;
 #endif // __OBJC__
 
+#include <audioapi/core/CommonPlayer.h>
 #include <audioapi/utils/AudioBuffer.hpp>
 
 #include <atomic>
@@ -16,22 +17,22 @@ namespace audioapi {
 
 class AudioContext;
 
-class IOSAudioPlayer {
+class IOSAudioPlayer : public CommonPlayer {
  public:
   IOSAudioPlayer(
       const std::function<void(DSPAudioBuffer *, int)> &renderAudio,
       float sampleRate,
       int channelCount,
       std::atomic<uint32_t> &currentRenders);
-  ~IOSAudioPlayer();
+  ~IOSAudioPlayer() override;
 
-  bool start();
-  void stop();
-  bool resume();
-  void suspend();
-  void cleanup();
+  bool start() override;
+  void stop() override;
+  bool resume() override;
+  void suspend() override;
+  void cleanup() override;
 
-  bool isRunning() const;
+  [[nodiscard]] bool isRunning() const override;
 
  private:
   void clearPendingSaved();

--- a/packages/react-native-audio-api/wpt_tests/src/NodeAudioPlayer.h
+++ b/packages/react-native-audio-api/wpt_tests/src/NodeAudioPlayer.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <audioapi/core/CommonPlayer.h>
 #include <audioapi/utils/AudioBuffer.hpp>
 
 #include <atomic>
@@ -9,21 +10,21 @@
 
 namespace audioapi {
 
-class NodeAudioPlayer final {
+class NodeAudioPlayer final : public CommonPlayer {
  public:
   NodeAudioPlayer(
       const std::function<void(DSPAudioBuffer *, int)> &renderAudio,
       float sampleRate,
       int channelCount);
-  ~NodeAudioPlayer();
+  ~NodeAudioPlayer() override;
 
-  bool start();
-  void stop();
-  bool resume();
-  void suspend();
-  void cleanup();
+  bool start() override;
+  void stop() override;
+  bool resume() override;
+  void suspend() override;
+  void cleanup() override;
 
-  [[nodiscard]] bool isRunning() const;
+  [[nodiscard]] bool isRunning() const override;
 
  private:
   void run();


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes [RNAA-501](https://linear.app/softwaremansion/issue/RNAA-501/audio-player-common-interface)

## ⚠️ Breaking changes ⚠️

<!-- A brief description of the breaking changes -->

- 
## Introduced changes

<!-- A brief description of the changes -->

- Created an interface in `CommonPlayer.h` for Android and IOS audio players, updated them accordingly.
- Updated `.claude/skills/thread-safety-itc/SKILL.md` with info about CommonPlayer.
- Removed `audioPlayer_->openAudioStream();` from AudioContext constructor in [packages/react-native-audio-api/common/cpp/audioapi/core/AudioContext.cpp](https://github.com/software-mansion/react-native-audio-api/compare/feat/rnaa-501-audio-player-common-interface?expand=1#diff-6fb612b2976631b828051c1f102cc8016644c0bb4341bb9a979354e3af9021a5), in place of that created lazy loading in [packages/react-native-audio-api/android/src/main/cpp/audioapi/android/core/AudioPlayer.cpp](https://github.com/software-mansion/react-native-audio-api/compare/feat/rnaa-501-audio-player-common-interface?expand=1#diff-fd0510415a4801148d5dfa418206e47f014ac64288a201af374cca61c36036b9). Lazy loading was already present on IOS.
- Updated `apps/fabric-example/ios/FabricExampleTests/AudioPlayerTests.mm` and `packages/react-native-audio-api/wpt_tests/src/NodeAudioPlayer.h`.


## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added/Conducted relevant tests
- [ ] Performed self-review of the code
- [ ] Updated Web Audio API coverage
- [ ] Added support for web
- [ ] Updated old arch android spec file