### PR TITLE
audioscheduledsource node memory leak fix

### DIFF
--- a/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioScheduledSourceNode.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioScheduledSourceNode.cpp
@@ -44,13 +44,14 @@ void AudioScheduledSourceNode::stop(double when) {
   auto stopFrame = dsp::timeToSampleFrame(stopTime_, context->getSampleRate());
   // if stop is requested before start, mark as finished
   if (stopFrame <= startFrame) {
-    // Fire-and-forget: defer finish/disable off the caller thread.
+    playbackState_ = PlaybackState::FINISHED;
+    AudioNode::disable();
+    // Fire-and-forget: defer event dispatch off the caller thread.
     static constexpr double kMillisecondsPerSecond = 1000.0;
     std::thread([this]() {
       std::this_thread::sleep_for(
           std::chrono::milliseconds(static_cast<int>(stopTime_ * kMillisecondsPerSecond)));
-      playbackState_ = PlaybackState::FINISHED;
-      disable();
+      onEndedEvent_.dispatchEmpty();
     }).detach();
     return;
   }

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioScheduledSourceNode.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioScheduledSourceNode.cpp
@@ -3,14 +3,15 @@
 #include <audioapi/dsp/AudioUtils.hpp>
 #include <audioapi/events/AudioEventHandlerRegistry.h>
 #include <audioapi/utils/AudioArray.hpp>
-
 #if !RN_AUDIO_API_TEST
 #include <audioapi/core/AudioContext.h>
 #endif // RN_AUDIO_API_TEST
 
 #include <algorithm>
+#include <chrono>
 #include <limits>
 #include <memory>
+#include <thread>
 
 namespace audioapi {
 
@@ -38,6 +39,21 @@ void AudioScheduledSourceNode::start(double when) {
 
 void AudioScheduledSourceNode::stop(double when) {
   stopTime_ = when;
+  auto context = context_.lock();
+  auto startFrame = dsp::timeToSampleFrame(startTime_, context->getSampleRate());
+  auto stopFrame = dsp::timeToSampleFrame(stopTime_, context->getSampleRate());
+  // if stop is requested before start, mark as finished
+  if (stopFrame <= startFrame) {
+    // Fire-and-forget: defer finish/disable off the caller thread.
+    static constexpr double kMillisecondsPerSecond = 1000.0;
+    std::thread([this]() {
+      std::this_thread::sleep_for(
+          std::chrono::milliseconds(static_cast<int>(stopTime_ * kMillisecondsPerSecond)));
+      playbackState_ = PlaybackState::FINISHED;
+      disable();
+    }).detach();
+    return;
+  }
 }
 
 bool AudioScheduledSourceNode::isUnscheduled() const {


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #1187

## ⚠️ Breaking changes ⚠️

<!-- A brief description of the breaking changes -->

-

## Introduced changes

<!-- A brief description of the changes -->

- when audio scheduled source node was stopped before start, it leaked memory 
- it cannot be immediately stopped, because `onended` event time fire has to be respected

**Before:**
<img width="1021" height="529" alt="image" src="https://github.com/user-attachments/assets/07dbcfb8-d178-4b6a-bf9e-e4410e309bf1" />


**After:**
<img width="1024" height="551" alt="image" src="https://github.com/user-attachments/assets/fc15ab7b-ef74-4d8e-9bf9-a965eba049ff" />


## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added/Conducted relevant tests
- [ ] Performed self-review of the code
- [ ] Updated Web Audio API coverage
- [ ] Added support for web
- [ ] Updated old arch android spec file
