### PR TITLE
fix: render queue event resolution

### DIFF
--- a/packages/react-native-audio-api/src/core/AudioParam.ts
+++ b/packages/react-native-audio-api/src/core/AudioParam.ts
@@ -29,6 +29,7 @@ export default class AudioParam {
 
   public set value(value: number) {
     this.audioParam.value = value;
+    this.setValueAtTime(value, this.context.currentTime);
   }
 
   public setValueAtTime(value: number, startTime: number): AudioParam {


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #1191 

## ⚠️ Breaking changes ⚠️

<!-- A brief description of the breaking changes -->

- `AudioParam.value` setter will have stricter curve checks (literally the same as `setValueAtTime`) as per spec:

>**value**, of type [float](https://webidl.spec.whatwg.org/#idl-float)
>Setting this attribute has the effect of assigning the requested value to the [[[current value]]](https://webaudio.github.io/web-audio-api/#dom-audioparam-current-value-slot) slot, and calling the [setValueAtTime()](https://webaudio.github.io/web-audio-api/#dom-audioparam-setvalueattime) method with the current [AudioContext](https://webaudio.github.io/web-audio-api/#AudioContext)’s currentTime and [[[current value]]](https://webaudio.github.io/web-audio-api/#dom-audioparam-current-value-slot). **Any exceptions that would be thrown by setValueAtTime() will also be thrown by setting this attribute.**

## Introduced changes

<!-- A brief description of the changes -->

 - `AudioParam.value` setter now invokes `setValueAtTime(value, context.currentTIme)`
   - this solves the bug that occurred when an `automation event` with no `startValue` (like `setTargetAtTime` or `RAMP` events) was scheduled without an explicit `setValueAtTime` call. In result, such event's `startValue` fallbacked to `defaultValue_` which then created audible jumps in pitch and sidebands in `fft` analysis.
   - Before:
   <img width="388" height="222" alt="image" src="https://github.com/user-attachments/assets/7f566874-7c5d-4899-b5b2-6fe6b81b0d9d" />

   - After:
   <img width="393" height="228" alt="image" src="https://github.com/user-attachments/assets/074ceae3-2de3-46d6-b1f3-72d8ceb3105c" />

## Other

> [!NOTE]
>  Identified issues with `WEB IDL` type checking. For example, currently `number.isFinite()` is rarely (if ever) called to check the passed values. Solving this may probably improve `wpt` tests results.

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added/Conducted relevant tests
- [x] Performed self-review of the code
- [x] Updated Web Audio API coverage
- [x] Added support for web
- [x] Updated old arch android spec file
