### PR TITLE
feat: AudioManager.getSystemVolume() — synchronous system volume read

### DIFF
--- a/packages/audiodocs/docs/system/audio-manager.mdx
+++ b/packages/audiodocs/docs/system/audio-manager.mdx
@@ -110,6 +110,12 @@ and tries to reactivate the audio session as soon as there is "silence", althoug
 Internally, the method uses `AVAudioSessionSilenceSecondaryAudioHintNotification` as well as
 interval polling to check if other audio is playing.
 
+### `getSystemVolume`
+
+Reads the current system output volume as a 0..1 fraction of its maximum.
+
+#### Returns `number`.
+
 ### `observeVolumeChanges`
 
 | Parameter | Type | Description |

--- a/packages/react-native-audio-api/android/src/main/java/com/swmansion/audioapi/AudioAPIModule.kt
+++ b/packages/react-native-audio-api/android/src/main/java/com/swmansion/audioapi/AudioAPIModule.kt
@@ -147,6 +147,8 @@ class AudioAPIModule(
     MediaSessionManager.observeVolumeChanges(enabled)
   }
 
+  override fun getSystemVolume(): Double = MediaSessionManager.getSystemVolume()
+
   override fun requestRecordingPermissions(promise: Promise) {
     val permissionRequestListener = PermissionRequestListener(promise)
     MediaSessionManager.requestRecordingPermissions(permissionRequestListener)

--- a/packages/react-native-audio-api/android/src/main/java/com/swmansion/audioapi/system/MediaSessionManager.kt
+++ b/packages/react-native-audio-api/android/src/main/java/com/swmansion/audioapi/system/MediaSessionManager.kt
@@ -83,6 +83,14 @@ object MediaSessionManager {
     this.notificationRegistry = NotificationRegistry(this.reactContext, this.audioAPIModule)
   }
 
+  /** The system output volume on the volumeChange event's own scale:
+   * STREAM_MUSIC volume as a 0..1 fraction of its maximum. */
+  fun getSystemVolume(): Double {
+    val current = audioManager.getStreamVolume(AudioManager.STREAM_MUSIC).toDouble()
+    val max = audioManager.getStreamMaxVolume(AudioManager.STREAM_MUSIC).toDouble()
+    return if (max > 0) current / max else 0.0
+  }
+
   fun getDevicePreferredSampleRate(): Double {
     val sampleRate = this.audioManager.getProperty(AudioManager.PROPERTY_OUTPUT_SAMPLE_RATE)
     return sampleRate.toDouble()

--- a/packages/react-native-audio-api/ios/audioapi/ios/AudioAPIModule.mm
+++ b/packages/react-native-audio-api/ios/audioapi/ios/AudioAPIModule.mm
@@ -92,6 +92,11 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(getDevicePreferredSampleRate)
   return [self.audioSessionManager getDevicePreferredSampleRate];
 }
 
+RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(getSystemVolume)
+{
+  return [self.audioSessionManager getSystemVolume];
+}
+
 RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(isFfmpegEnabled)
 {
 #if RN_AUDIO_API_FFMPEG_DISABLED

--- a/packages/react-native-audio-api/ios/audioapi/ios/system/AudioSessionManager.h
+++ b/packages/react-native-audio-api/ios/audioapi/ios/system/AudioSessionManager.h
@@ -40,6 +40,7 @@
 - (void)disableSessionManagement;
 
 - (NSNumber *)getDevicePreferredSampleRate;
+- (NSNumber *)getSystemVolume;
 - (NSString *)inputDiagnosticsSnapshot;
 
 - (void)requestRecordingPermissions:(RCTPromiseResolveBlock)resolve

--- a/packages/react-native-audio-api/ios/audioapi/ios/system/AudioSessionManager.mm
+++ b/packages/react-native-audio-api/ios/audioapi/ios/system/AudioSessionManager.mm
@@ -214,6 +214,11 @@ static AudioSessionManager *_sharedInstance = nil;
   return [NSNumber numberWithFloat:[self.audioSession sampleRate]];
 }
 
+- (NSNumber *)getSystemVolume
+{
+  return [NSNumber numberWithFloat:[self.audioSession outputVolume]];
+}
+
 - (NSString *)inputDiagnosticsSnapshot
 {
   AVAudioSessionRouteDescription *route = [self.audioSession currentRoute];

--- a/packages/react-native-audio-api/src/specs/NativeAudioAPIModule.ts
+++ b/packages/react-native-audio-api/src/specs/NativeAudioAPIModule.ts
@@ -32,6 +32,7 @@ interface Spec extends TurboModule {
   observeAudioInterruptions(focusType: AudioFocusType, enabled: boolean): void;
   activelyReclaimSession(enabled: boolean): void;
   observeVolumeChanges(enabled: boolean): void;
+  getSystemVolume(): number;
 
   // Permissions
   requestRecordingPermissions(): Promise<PermissionStatus>;

--- a/packages/react-native-audio-api/src/system/AudioManager.ts
+++ b/packages/react-native-audio-api/src/system/AudioManager.ts
@@ -81,6 +81,22 @@ class AudioManager implements IAudioManager {
     NativeAudioAPIModule.observeVolumeChanges(enabled);
   }
 
+  /**
+   * Synchronously reads the current system output volume as a 0..1 value,
+   * on the same scale the `volumeChange` event reports: AVAudioSession's
+   * outputVolume on iOS, the STREAM_MUSIC volume as a fraction of its
+   * maximum on Android. Complements `observeVolumeChanges`, which only
+   * reports on changes: this answers "what is it right now" before any
+   * change has fired.
+   *
+   * iOS note: a cold read before any volume-change event can report a stale
+   * or zero value on some iOS versions; treat the event stream as the truth
+   * once it speaks.
+   */
+  getSystemVolume(): number {
+    return NativeAudioAPIModule.getSystemVolume();
+  }
+
   addSystemEventListener<Name extends SystemEventName>(
     name: Name,
     callback: SystemEventCallback<Name>

--- a/packages/react-native-audio-api/src/system/AudioManager.ts
+++ b/packages/react-native-audio-api/src/system/AudioManager.ts
@@ -82,16 +82,12 @@ class AudioManager implements IAudioManager {
   }
 
   /**
-   * Synchronously reads the current system output volume as a 0..1 value,
-   * on the same scale the `volumeChange` event reports: AVAudioSession's
-   * outputVolume on iOS, the STREAM_MUSIC volume as a fraction of its
-   * maximum on Android. Complements `observeVolumeChanges`, which only
-   * reports on changes: this answers "what is it right now" before any
-   * change has fired.
+   * Synchronously reads the current system output volume as a 0..1 value, on
+   * the same scale the `volumeChange` event reports
    *
-   * iOS note: a cold read before any volume-change event can report a stale
-   * or zero value on some iOS versions; treat the event stream as the truth
-   * once it speaks.
+   * On iOS, a cold read before any volume-change event can report a stale or
+   * zero value on some OS versions; treat the event stream as the truth once it
+   * speaks.
    */
   getSystemVolume(): number {
     return NativeAudioAPIModule.getSystemVolume();

--- a/packages/react-native-audio-api/src/system/types.ts
+++ b/packages/react-native-audio-api/src/system/types.ts
@@ -91,4 +91,5 @@ export interface IAudioManager {
   checkNotificationPermissions(): Promise<PermissionStatus>;
   getDevicesInfo(): Promise<AudioDevicesInfo>;
   setInputDevice(deviceId: string): Promise<void>;
+  getSystemVolume(): number;
 }

--- a/packages/react-native-audio-api/src/system/types.ts
+++ b/packages/react-native-audio-api/src/system/types.ts
@@ -80,6 +80,7 @@ export interface IAudioManager {
   observeAudioInterruptions(enabled: boolean): void;
   activelyReclaimSession(enabled: boolean): void;
   observeAudioInterruptions(param: AudioFocusType | boolean | null): void;
+  getSystemVolume(): number;
   addSystemEventListener<Name extends SystemEventName>(
     name: Name,
     callback: SystemEventCallback<Name>

--- a/packages/react-native-audio-api/src/system/types.ts
+++ b/packages/react-native-audio-api/src/system/types.ts
@@ -91,5 +91,4 @@ export interface IAudioManager {
   checkNotificationPermissions(): Promise<PermissionStatus>;
   getDevicesInfo(): Promise<AudioDevicesInfo>;
   setInputDevice(deviceId: string): Promise<void>;
-  getSystemVolume(): number;
 }

--- a/packages/react-native-audio-api/src/web-system/AudioManager.ts
+++ b/packages/react-native-audio-api/src/web-system/AudioManager.ts
@@ -11,6 +11,7 @@ const mockSync =
 
 class AudioManager implements IAudioManager {
   getDevicePreferredSampleRate = mockSync(44100);
+  getSystemVolume = mockSync(1);
   setAudioSessionActivity = mockAsync(undefined);
   setAudioSessionOptions = mockSync({});
   disableSessionManagement = mockSync({});


### PR DESCRIPTION
## Why

`AudioManager` can observe volume changes (`observeVolumeChanges` + the `volumeChange` event) but has no way to read the volume **before any change has fired**. An app that wants to warn "your volume is at the floor" at the moment the user presses play cannot know the current level until the user happens to press a volume button.

## What

A synchronous read on the exact scale the `volumeChange` event already reports:

```ts
const volume = AudioManager.getSystemVolume(); // 0..1
```

- iOS: `AVAudioSession.outputVolume`
- Android: `STREAM_MUSIC` volume as a fraction of its maximum

Exposed via the TurboModule spec mirroring `getDevicePreferredSampleRate`'s blocking-synchronous form; the iOS implementation delegates to `AudioSessionManager` like its siblings.

## Notes

The JSDoc carries the honest iOS caveat: a cold read before any volume-change event can report a stale or zero value on some iOS versions (KVO on `outputVolume` is the trustworthy stream once it speaks); callers who care can treat an exact 0.0 cold read as suspect. That caveat exists with or without this API — this just gives apps the same read the KVO baseline uses.