### PR TITLE
refactor: replace AudioEventHandlerRegistry dependency with an interface

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,7 @@ packages/custom-node-generator/    # Code generation tooling
 - **New Architecture Ready**: Supports both old Bridge and new TurboModules/Fabric
 - **Optional FFmpeg**: Audio decoding via FFmpeg can be conditionally compiled out
 - **Audio Worklets**: JavaScript runs on the audio thread via React Native Worklets
+- **Testable C++ dependencies**: consumers take interface types (`std::shared_ptr<I…>`); construct concrete implementations only at platform bootstrap. Example: audio event registry (use `IAudioEventHandlerRegistry` more often than `AudioEventHandlerRegistry`).
 
 ### Native Module Entry Points
 - iOS: `ios/audioapi/ios/AudioAPIModule.mm`

--- a/apps/fabric-example/ios/FabricExampleTests/IOSAudioRecorderTests.mm
+++ b/apps/fabric-example/ios/FabricExampleTests/IOSAudioRecorderTests.mm
@@ -22,11 +22,11 @@ static NSString *NSStringFromStdString(const std::string &value)
 
 namespace audioapi {
 
-class AudioEventHandlerRegistry;
+class IAudioEventHandlerRegistry;
 
 class IOSAudioRecorder : public AudioRecorder {
  public:
-  IOSAudioRecorder(const std::shared_ptr<AudioEventHandlerRegistry> &audioEventHandlerRegistry);
+  IOSAudioRecorder(const std::shared_ptr<IAudioEventHandlerRegistry> &audioEventHandlerRegistry);
   ~IOSAudioRecorder() override;
 
   Result<NoneType, std::string> start(const std::string &fileNameOverride = "") override;
@@ -242,7 +242,7 @@ static RecorderAdapterTestFixture makeRecorderAdapterFixture()
 class TestableIOSAudioRecorder : public IOSAudioRecorder {
  public:
   explicit TestableIOSAudioRecorder(
-      const std::shared_ptr<AudioEventHandlerRegistry> &audioEventHandlerRegistry)
+      const std::shared_ptr<IAudioEventHandlerRegistry> &audioEventHandlerRegistry)
       : IOSAudioRecorder(audioEventHandlerRegistry) {}
 
   NativeAudioRecorder *replaceNativeRecorder(NativeAudioRecorder *nativeRecorder)
@@ -315,7 +315,7 @@ class TestableIOSAudioRecorder : public IOSAudioRecorder {
   self.audioEngine = [[FakeIOSRecorderAudioEngine alloc] init];
   self.nativeRecorder = [[FakeNativeAudioRecorder alloc] init];
 
-  _recorder = std::make_unique<TestableIOSAudioRecorder>(std::shared_ptr<AudioEventHandlerRegistry>());
+  _recorder = std::make_unique<TestableIOSAudioRecorder>(std::shared_ptr<IAudioEventHandlerRegistry>());
   self.originalNativeRecorder = _recorder->replaceNativeRecorder(self.nativeRecorder);
 }
 

--- a/packages/react-native-audio-api/android/src/main/cpp/audioapi/android/core/AndroidAudioRecorder.cpp
+++ b/packages/react-native-audio-api/android/src/main/cpp/audioapi/android/core/AndroidAudioRecorder.cpp
@@ -12,7 +12,7 @@
 #include <audioapi/core/sources/RecorderAdapterNode.h>
 #include <audioapi/core/utils/Constants.h>
 #include <audioapi/core/utils/Locker.h>
-#include <audioapi/events/AudioEventHandlerRegistry.h>
+#include <audioapi/events/IAudioEventHandlerRegistry.h>
 #include <audioapi/utils/AudioFileProperties.h>
 #include <audioapi/utils/CircularArray.hpp>
 #include <audioapi/utils/CircularOverflowableAudioArray.h>
@@ -25,7 +25,7 @@
 namespace audioapi {
 
 AndroidAudioRecorder::AndroidAudioRecorder(
-    const std::shared_ptr<AudioEventHandlerRegistry> &audioEventHandlerRegistry)
+    const std::shared_ptr<IAudioEventHandlerRegistry> &audioEventHandlerRegistry)
     : AudioRecorder(audioEventHandlerRegistry),
       streamSampleRate_(0.0),
       streamChannelCount_(0),

--- a/packages/react-native-audio-api/android/src/main/cpp/audioapi/android/core/AndroidAudioRecorder.h
+++ b/packages/react-native-audio-api/android/src/main/cpp/audioapi/android/core/AndroidAudioRecorder.h
@@ -18,14 +18,14 @@ namespace audioapi {
 class AudioFileProperties;
 class AndroidRecorderCallback;
 class AndroidFileWriterBackend;
-class AudioEventHandlerRegistry;
+class IAudioEventHandlerRegistry;
 
 class AndroidAudioRecorder : public oboe::AudioStreamCallback,
                              public AudioRecorder,
                              public std::enable_shared_from_this<AndroidAudioRecorder> {
  public:
   explicit AndroidAudioRecorder(
-      const std::shared_ptr<AudioEventHandlerRegistry> &audioEventHandlerRegistry);
+      const std::shared_ptr<IAudioEventHandlerRegistry> &audioEventHandlerRegistry);
   ~AndroidAudioRecorder() override;
   void cleanup();
 

--- a/packages/react-native-audio-api/android/src/main/cpp/audioapi/android/core/utils/AndroidFileWriterBackend.cpp
+++ b/packages/react-native-audio-api/android/src/main/cpp/audioapi/android/core/utils/AndroidFileWriterBackend.cpp
@@ -8,7 +8,7 @@
 
 namespace audioapi {
 AndroidFileWriterBackend::AndroidFileWriterBackend(
-    const std::shared_ptr<AudioEventHandlerRegistry> &audioEventHandlerRegistry,
+    const std::shared_ptr<IAudioEventHandlerRegistry> &audioEventHandlerRegistry,
     const std::shared_ptr<AudioFileProperties> &fileProperties)
     : AudioFileWriter(audioEventHandlerRegistry, fileProperties) {}
 

--- a/packages/react-native-audio-api/android/src/main/cpp/audioapi/android/core/utils/AndroidFileWriterBackend.h
+++ b/packages/react-native-audio-api/android/src/main/cpp/audioapi/android/core/utils/AndroidFileWriterBackend.h
@@ -23,7 +23,7 @@ class AudioFileProperties;
 class AndroidFileWriterBackend : public AudioFileWriter {
  public:
   explicit AndroidFileWriterBackend(
-      const std::shared_ptr<AudioEventHandlerRegistry> &audioEventHandlerRegistry,
+      const std::shared_ptr<IAudioEventHandlerRegistry> &audioEventHandlerRegistry,
       const std::shared_ptr<AudioFileProperties> &fileProperties);
 
   void writeAudioData(AudioDataType data, int numFrames) override;

--- a/packages/react-native-audio-api/android/src/main/cpp/audioapi/android/core/utils/AndroidRecorderCallback.cpp
+++ b/packages/react-native-audio-api/android/src/main/cpp/audioapi/android/core/utils/AndroidRecorderCallback.cpp
@@ -1,7 +1,7 @@
 #include <android/log.h>
 #include <audioapi/HostObjects/sources/AudioBufferHostObject.h>
 #include <audioapi/android/core/utils/AndroidRecorderCallback.h>
-#include <audioapi/events/AudioEventHandlerRegistry.h>
+#include <audioapi/events/IAudioEventHandlerRegistry.h>
 #include <audioapi/libs/miniaudio/miniaudio.h>
 #include <audioapi/utils/AudioArray.hpp>
 #include <audioapi/utils/CircularArray.hpp>
@@ -26,7 +26,7 @@ namespace audioapi {
 /// @param channelCount The user desired channel count
 /// @param callbackId The callback identifier
 AndroidRecorderCallback::AndroidRecorderCallback(
-    const std::shared_ptr<AudioEventHandlerRegistry> &audioEventHandlerRegistry,
+    const std::shared_ptr<IAudioEventHandlerRegistry> &audioEventHandlerRegistry,
     float sampleRate,
     size_t bufferLength,
     int channelCount,

--- a/packages/react-native-audio-api/android/src/main/cpp/audioapi/android/core/utils/AndroidRecorderCallback.h
+++ b/packages/react-native-audio-api/android/src/main/cpp/audioapi/android/core/utils/AndroidRecorderCallback.h
@@ -14,7 +14,7 @@
 
 namespace audioapi {
 
-class AudioEventHandlerRegistry;
+class IAudioEventHandlerRegistry;
 
 struct CallbackData {
   size_t slot = std::numeric_limits<size_t>::max();
@@ -24,7 +24,7 @@ struct CallbackData {
 class AndroidRecorderCallback : public AudioRecorderCallback {
  public:
   AndroidRecorderCallback(
-      const std::shared_ptr<AudioEventHandlerRegistry> &audioEventHandlerRegistry,
+      const std::shared_ptr<IAudioEventHandlerRegistry> &audioEventHandlerRegistry,
       float sampleRate,
       size_t bufferLength,
       int channelCount,

--- a/packages/react-native-audio-api/android/src/main/cpp/audioapi/android/core/utils/AndroidRotatingFileWriter.cpp
+++ b/packages/react-native-audio-api/android/src/main/cpp/audioapi/android/core/utils/AndroidRotatingFileWriter.cpp
@@ -9,7 +9,7 @@
 namespace audioapi {
 
 AndroidRotatingFileWriter::AndroidRotatingFileWriter(
-    const std::shared_ptr<AudioEventHandlerRegistry> &audioEventHandlerRegistry,
+    const std::shared_ptr<IAudioEventHandlerRegistry> &audioEventHandlerRegistry,
     const std::shared_ptr<AudioFileProperties> &fileProperties,
     size_t rotateIntervalBytes,
     WriterFactory writerFactory,

--- a/packages/react-native-audio-api/android/src/main/cpp/audioapi/android/core/utils/AndroidRotatingFileWriter.h
+++ b/packages/react-native-audio-api/android/src/main/cpp/audioapi/android/core/utils/AndroidRotatingFileWriter.h
@@ -16,7 +16,7 @@ class AndroidRotatingFileWriter : public AndroidFileWriterBackend, public Rotati
       std::function<std::shared_ptr<AudioFileWriter>(const std::shared_ptr<AudioFileProperties> &)>;
 
   AndroidRotatingFileWriter(
-      const std::shared_ptr<AudioEventHandlerRegistry> &audioEventHandlerRegistry,
+      const std::shared_ptr<IAudioEventHandlerRegistry> &audioEventHandlerRegistry,
       const std::shared_ptr<AudioFileProperties> &fileProperties,
       size_t rotateIntervalBytes,
       WriterFactory writerFactory,

--- a/packages/react-native-audio-api/android/src/main/cpp/audioapi/android/core/utils/ffmpegBackend/FFmpegFileWriter.cpp
+++ b/packages/react-native-audio-api/android/src/main/cpp/audioapi/android/core/utils/ffmpegBackend/FFmpegFileWriter.cpp
@@ -33,7 +33,7 @@ constexpr int defaultFlushInterval = 100;
 namespace audioapi::android::ffmpeg {
 
 FFmpegAudioFileWriter::FFmpegAudioFileWriter(
-    const std::shared_ptr<AudioEventHandlerRegistry> &audioEventHandlerRegistry,
+    const std::shared_ptr<IAudioEventHandlerRegistry> &audioEventHandlerRegistry,
     const std::shared_ptr<AudioFileProperties> &fileProperties,
     float streamSampleRate,
     int32_t streamChannelCount,

--- a/packages/react-native-audio-api/android/src/main/cpp/audioapi/android/core/utils/ffmpegBackend/FFmpegFileWriter.h
+++ b/packages/react-native-audio-api/android/src/main/cpp/audioapi/android/core/utils/ffmpegBackend/FFmpegFileWriter.h
@@ -24,7 +24,7 @@ namespace android::ffmpeg {
 class FFmpegAudioFileWriter : public AndroidFileWriterBackend {
  public:
   explicit FFmpegAudioFileWriter(
-      const std::shared_ptr<AudioEventHandlerRegistry> &audioEventHandlerRegistry,
+      const std::shared_ptr<IAudioEventHandlerRegistry> &audioEventHandlerRegistry,
       const std::shared_ptr<AudioFileProperties> &fileProperties,
       float streamSampleRate,
       int32_t streamChannelCount,

--- a/packages/react-native-audio-api/android/src/main/cpp/audioapi/android/core/utils/miniaudioBackend/MiniAudioFileWriter.cpp
+++ b/packages/react-native-audio-api/android/src/main/cpp/audioapi/android/core/utils/miniaudioBackend/MiniAudioFileWriter.cpp
@@ -41,7 +41,7 @@ inline ma_format getDataFormat(const std::shared_ptr<AudioFileProperties> &prope
 }
 
 MiniAudioFileWriter::MiniAudioFileWriter(
-    const std::shared_ptr<AudioEventHandlerRegistry> &audioEventHandlerRegistry,
+    const std::shared_ptr<IAudioEventHandlerRegistry> &audioEventHandlerRegistry,
     const std::shared_ptr<AudioFileProperties> &fileProperties,
     float streamSampleRate,
     int32_t streamChannelCount,

--- a/packages/react-native-audio-api/android/src/main/cpp/audioapi/android/core/utils/miniaudioBackend/MiniAudioFileWriter.h
+++ b/packages/react-native-audio-api/android/src/main/cpp/audioapi/android/core/utils/miniaudioBackend/MiniAudioFileWriter.h
@@ -12,7 +12,7 @@ namespace audioapi {
 class MiniAudioFileWriter : public AndroidFileWriterBackend {
  public:
   explicit MiniAudioFileWriter(
-      const std::shared_ptr<AudioEventHandlerRegistry> &audioEventHandlerRegistry,
+      const std::shared_ptr<IAudioEventHandlerRegistry> &audioEventHandlerRegistry,
       const std::shared_ptr<AudioFileProperties> &fileProperties,
       float streamSampleRate,
       int32_t streamChannelCount,

--- a/packages/react-native-audio-api/common/cpp/audioapi/AudioAPIModuleInstaller.h
+++ b/packages/react-native-audio-api/common/cpp/audioapi/AudioAPIModuleInstaller.h
@@ -13,7 +13,7 @@
 #include <audioapi/utils/AudioBuffer.hpp>
 
 #include <audioapi/HostObjects/events/AudioEventHandlerRegistryHostObject.h>
-#include <audioapi/events/AudioEventHandlerRegistry.h>
+#include <audioapi/events/IAudioEventHandlerRegistry.h>
 
 #include <memory>
 namespace audioapi {
@@ -25,7 +25,7 @@ class AudioAPIModuleInstaller {
   static void injectJSIBindings(
       jsi::Runtime *jsiRuntime,
       const std::shared_ptr<react::CallInvoker> &jsCallInvoker,
-      const std::shared_ptr<AudioEventHandlerRegistry> &audioEventHandlerRegistry) {
+      const std::shared_ptr<IAudioEventHandlerRegistry> &audioEventHandlerRegistry) {
     auto createAudioContext =
         getCreateAudioContextFunction(jsiRuntime, jsCallInvoker, audioEventHandlerRegistry);
     auto createAudioRecorder =
@@ -56,7 +56,7 @@ class AudioAPIModuleInstaller {
   static jsi::Function getCreateAudioContextFunction(
       jsi::Runtime *jsiRuntime,
       const std::shared_ptr<react::CallInvoker> &jsCallInvoker,
-      const std::shared_ptr<AudioEventHandlerRegistry> &audioEventHandlerRegistry) {
+      const std::shared_ptr<IAudioEventHandlerRegistry> &audioEventHandlerRegistry) {
     return jsi::Function::createFromHostFunction(
         *jsiRuntime,
         jsi::PropNameID::forAscii(*jsiRuntime, "createAudioContext"),
@@ -78,7 +78,7 @@ class AudioAPIModuleInstaller {
   static jsi::Function getCreateOfflineAudioContextFunction(
       jsi::Runtime *jsiRuntime,
       const std::shared_ptr<react::CallInvoker> &jsCallInvoker,
-      const std::shared_ptr<AudioEventHandlerRegistry> &audioEventHandlerRegistry) {
+      const std::shared_ptr<IAudioEventHandlerRegistry> &audioEventHandlerRegistry) {
     return jsi::Function::createFromHostFunction(
         *jsiRuntime,
         jsi::PropNameID::forAscii(*jsiRuntime, "createOfflineAudioContext"),
@@ -107,7 +107,7 @@ class AudioAPIModuleInstaller {
   static jsi::Function getCreateAudioRecorderFunction(
       jsi::Runtime *jsiRuntime,
       const std::shared_ptr<react::CallInvoker> &jsCallInvoker,
-      const std::shared_ptr<AudioEventHandlerRegistry> &audioEventHandlerRegistry) {
+      const std::shared_ptr<IAudioEventHandlerRegistry> &audioEventHandlerRegistry) {
     return jsi::Function::createFromHostFunction(
         *jsiRuntime,
         jsi::PropNameID::forAscii(*jsiRuntime, "createAudioRecorder"),

--- a/packages/react-native-audio-api/common/cpp/audioapi/HostObjects/events/AudioEventHandlerRegistryHostObject.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/HostObjects/events/AudioEventHandlerRegistryHostObject.cpp
@@ -1,13 +1,13 @@
 #include <audioapi/HostObjects/events/AudioEventHandlerRegistryHostObject.h>
 
 #include <audioapi/HostObjects/utils/JsEnumParser.h>
-#include <audioapi/events/AudioEventHandlerRegistry.h>
+#include <audioapi/events/IAudioEventHandlerRegistry.h>
 #include <memory>
 
 namespace audioapi {
 
 AudioEventHandlerRegistryHostObject::AudioEventHandlerRegistryHostObject(
-    const std::shared_ptr<AudioEventHandlerRegistry> &eventHandlerRegistry)
+    const std::shared_ptr<IAudioEventHandlerRegistry> &eventHandlerRegistry)
     : eventHandlerRegistry_(eventHandlerRegistry) {
   addFunctions(
       JSI_EXPORT_FUNCTION(AudioEventHandlerRegistryHostObject, addAudioEventListener),

--- a/packages/react-native-audio-api/common/cpp/audioapi/HostObjects/events/AudioEventHandlerRegistryHostObject.h
+++ b/packages/react-native-audio-api/common/cpp/audioapi/HostObjects/events/AudioEventHandlerRegistryHostObject.h
@@ -9,21 +9,21 @@
 namespace audioapi {
 using namespace facebook;
 
-class AudioEventHandlerRegistry;
+class IAudioEventHandlerRegistry;
 
 class AudioEventHandlerRegistryHostObject : public HostObject {
  public:
   explicit AudioEventHandlerRegistryHostObject(
-      const std::shared_ptr<AudioEventHandlerRegistry> &eventHandlerRegistry);
+      const std::shared_ptr<IAudioEventHandlerRegistry> &eventHandlerRegistry);
 
   JSI_HOST_FUNCTION_DECL(addAudioEventListener);
   JSI_HOST_FUNCTION_DECL(removeAudioEventListener);
 
-  [[nodiscard]] const std::shared_ptr<AudioEventHandlerRegistry> &getEventHandlerRegistry() const {
+  [[nodiscard]] const std::shared_ptr<IAudioEventHandlerRegistry> &getEventHandlerRegistry() const {
     return eventHandlerRegistry_;
   }
 
  private:
-  std::shared_ptr<AudioEventHandlerRegistry> eventHandlerRegistry_;
+  std::shared_ptr<IAudioEventHandlerRegistry> eventHandlerRegistry_;
 };
 } // namespace audioapi

--- a/packages/react-native-audio-api/common/cpp/audioapi/HostObjects/inputs/AudioRecorderHostObject.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/HostObjects/inputs/AudioRecorderHostObject.cpp
@@ -3,7 +3,7 @@
 #include <audioapi/HostObjects/sources/AudioBufferHostObject.h>
 #include <audioapi/HostObjects/sources/RecorderAdapterNodeHostObject.h>
 #include <audioapi/core/inputs/AudioRecorder.h>
-#include <audioapi/events/AudioEventHandlerRegistry.h>
+#include <audioapi/events/IAudioEventHandlerRegistry.h>
 #include <audioapi/jsi/JsiPromise.h>
 #include <audioapi/jsi/JsiUtils.h>
 #include <audioapi/utils/AudioBuffer.hpp>
@@ -20,7 +20,7 @@
 namespace audioapi {
 
 AudioRecorderHostObject::AudioRecorderHostObject(
-    const std::shared_ptr<AudioEventHandlerRegistry> &audioEventHandlerRegistry,
+    const std::shared_ptr<IAudioEventHandlerRegistry> &audioEventHandlerRegistry,
     jsi::Runtime *runtime,
     const std::shared_ptr<react::CallInvoker> &callInvoker) {
 #ifdef ANDROID

--- a/packages/react-native-audio-api/common/cpp/audioapi/HostObjects/inputs/AudioRecorderHostObject.h
+++ b/packages/react-native-audio-api/common/cpp/audioapi/HostObjects/inputs/AudioRecorderHostObject.h
@@ -10,12 +10,12 @@ namespace audioapi {
 using namespace facebook;
 
 class AudioRecorder;
-class AudioEventHandlerRegistry;
+class IAudioEventHandlerRegistry;
 
 class AudioRecorderHostObject : public HostObject {
  public:
   AudioRecorderHostObject(
-      const std::shared_ptr<AudioEventHandlerRegistry> &audioEventHandlerRegistry,
+      const std::shared_ptr<IAudioEventHandlerRegistry> &audioEventHandlerRegistry,
       jsi::Runtime *runtime,
       const std::shared_ptr<react::CallInvoker> &callInvoker);
 

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/BaseAudioContext.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/BaseAudioContext.cpp
@@ -1,7 +1,7 @@
 #include <audioapi/core/BaseAudioContext.h>
 #include <audioapi/core/destinations/AudioDestinationNode.h>
 #include <audioapi/core/utils/AudioDecoding.h>
-#include <audioapi/events/AudioEventHandlerRegistry.h>
+#include <audioapi/events/IAudioEventHandlerRegistry.h>
 #include <audioapi/utils/AudioArray.hpp>
 #include <audioapi/utils/CircularArray.hpp>
 #ifdef DEBUG

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/BaseAudioContext.h
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/BaseAudioContext.h
@@ -22,7 +22,6 @@
 
 namespace audioapi {
 
-class AudioEventHandlerRegistry;
 class IAudioEventHandlerRegistry;
 class PeriodicWave;
 class AudioDestinationNode;

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/inputs/AudioRecorder.h
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/inputs/AudioRecorder.h
@@ -14,13 +14,13 @@ namespace audioapi {
 class AudioFileWriter;
 class AudioFileProperties;
 class AudioRecorderCallback;
-class AudioEventHandlerRegistry;
+class IAudioEventHandlerRegistry;
 
 class AudioRecorder {
  public:
   enum class RecorderState : uint8_t { Idle = 0, Recording, Paused };
   explicit AudioRecorder(
-      const std::shared_ptr<AudioEventHandlerRegistry> &audioEventHandlerRegistry)
+      const std::shared_ptr<IAudioEventHandlerRegistry> &audioEventHandlerRegistry)
       : audioEventHandlerRegistry_(audioEventHandlerRegistry) {}
   AudioRecorder(const AudioRecorder &) = delete;
   AudioRecorder(AudioRecorder &&) = delete;
@@ -89,7 +89,7 @@ class AudioRecorder {
   std::shared_ptr<AudioFileWriter> fileWriter_ = nullptr;
   std::shared_ptr<utils::graph::NodeHandle> adapterNodeHandle_ = nullptr;
   std::shared_ptr<AudioRecorderCallback> dataCallback_ = nullptr;
-  std::shared_ptr<AudioEventHandlerRegistry> audioEventHandlerRegistry_;
+  std::shared_ptr<IAudioEventHandlerRegistry> audioEventHandlerRegistry_;
   std::shared_ptr<AudioFileProperties> fileProperties_ = nullptr;
 };
 

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioBufferQueueSourceNode.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioBufferQueueSourceNode.cpp
@@ -5,7 +5,7 @@
 #include <audioapi/core/utils/Locker.h>
 #include <audioapi/core/utils/buffer/QueueBufferProcessor.h>
 #include <audioapi/dsp/AudioUtils.h>
-#include <audioapi/events/AudioEventHandlerRegistry.h>
+#include <audioapi/events/IAudioEventHandlerRegistry.h>
 #include <audioapi/types/NodeOptions.h>
 #include <audioapi/utils/AudioArray.hpp>
 

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioBufferSourceNode.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioBufferSourceNode.cpp
@@ -4,7 +4,7 @@
 #include <audioapi/core/utils/Constants.h>
 #include <audioapi/core/utils/Locker.h>
 #include <audioapi/dsp/AudioUtils.h>
-#include <audioapi/events/AudioEventHandlerRegistry.h>
+#include <audioapi/events/IAudioEventHandlerRegistry.h>
 #include <audioapi/types/NodeOptions.h>
 #include <audioapi/utils/AudioArray.hpp>
 

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioScheduledSourceNode.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioScheduledSourceNode.cpp
@@ -1,7 +1,7 @@
 #include <audioapi/core/BaseAudioContext.h>
 #include <audioapi/core/sources/AudioScheduledSourceNode.h>
 #include <audioapi/dsp/AudioUtils.h>
-#include <audioapi/events/AudioEventHandlerRegistry.h>
+#include <audioapi/events/IAudioEventHandlerRegistry.h>
 #include <audioapi/utils/AudioArray.hpp>
 #if !RN_AUDIO_API_TEST
 #include <audioapi/core/AudioContext.h>

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioScheduledSourceNode.h
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioScheduledSourceNode.h
@@ -11,8 +11,6 @@
 
 namespace audioapi {
 
-class IAudioEventHandlerRegistry;
-
 class AudioScheduledSourceNode : public AudioNode {
  public:
   // UNSCHEDULED: The node is not scheduled to play.

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/utils/AudioFileWriter.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/utils/AudioFileWriter.cpp
@@ -1,13 +1,13 @@
 #include <audioapi/core/utils/AudioFileWriter.h>
-#include <audioapi/events/AudioEventHandlerRegistry.h>
 #include <audioapi/events/AudioEventPayload.h>
+#include <audioapi/events/IAudioEventHandlerRegistry.h>
 #include <memory>
 #include <string>
 
 namespace audioapi {
 
 AudioFileWriter::AudioFileWriter(
-    const std::shared_ptr<AudioEventHandlerRegistry> &audioEventHandlerRegistry,
+    const std::shared_ptr<IAudioEventHandlerRegistry> &audioEventHandlerRegistry,
     const std::shared_ptr<AudioFileProperties> &fileProperties)
     : errorEvent_(audioEventHandlerRegistry), fileProperties_(fileProperties) {}
 

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/utils/AudioFileWriter.h
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/utils/AudioFileWriter.h
@@ -18,7 +18,7 @@ typedef void *AudioDataType;
 namespace audioapi {
 
 class AudioFileProperties;
-class AudioEventHandlerRegistry;
+class IAudioEventHandlerRegistry;
 
 using OpenFileResult = Result<std::string, std::string>;
 using CloseFileResult = Result<std::tuple<double, double>, std::string>;
@@ -28,7 +28,7 @@ class AudioFileWriter {
   DELETE_COPY_AND_MOVE(AudioFileWriter);
 
   AudioFileWriter(
-      const std::shared_ptr<AudioEventHandlerRegistry> &audioEventHandlerRegistry,
+      const std::shared_ptr<IAudioEventHandlerRegistry> &audioEventHandlerRegistry,
       const std::shared_ptr<AudioFileProperties> &fileProperties);
   virtual ~AudioFileWriter() = default;
 

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/utils/AudioRecorderCallback.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/utils/AudioRecorderCallback.cpp
@@ -2,7 +2,7 @@
 #include <audioapi/core/utils/AudioRecorderCallback.h>
 
 #include <audioapi/HostObjects/sources/AudioBufferHostObject.h>
-#include <audioapi/events/AudioEventHandlerRegistry.h>
+#include <audioapi/events/IAudioEventHandlerRegistry.h>
 #include <audioapi/utils/CircularArray.hpp>
 
 #include <audioapi/events/AudioEventPayload.h>
@@ -20,7 +20,7 @@ namespace audioapi {
 /// @param channelCount The user desired channel count
 /// @param callbackId The callback identifier
 AudioRecorderCallback::AudioRecorderCallback(
-    const std::shared_ptr<AudioEventHandlerRegistry> &audioEventHandlerRegistry,
+    const std::shared_ptr<IAudioEventHandlerRegistry> &audioEventHandlerRegistry,
     float sampleRate,
     size_t bufferLength,
     int channelCount,

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/utils/AudioRecorderCallback.h
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/utils/AudioRecorderCallback.h
@@ -15,12 +15,12 @@
 
 namespace audioapi {
 
-class AudioEventHandlerRegistry;
+class IAudioEventHandlerRegistry;
 
 class AudioRecorderCallback {
  public:
   AudioRecorderCallback(
-      const std::shared_ptr<AudioEventHandlerRegistry> &audioEventHandlerRegistry,
+      const std::shared_ptr<IAudioEventHandlerRegistry> &audioEventHandlerRegistry,
       float sampleRate,
       size_t bufferLength,
       int channelCount,

--- a/packages/react-native-audio-api/common/cpp/audioapi/events/IAudioEventHandlerRegistry.h
+++ b/packages/react-native-audio-api/common/cpp/audioapi/events/IAudioEventHandlerRegistry.h
@@ -7,9 +7,9 @@
 #include <cstdint>
 #include <memory>
 
-// interface exists only for the sake of testing
-// in every other case, AudioEventHandlerRegistry is used
-// when looking for implementations, look for AudioEventHandlerRegistry
+// Production modules depend on this interface so tests
+// can inject a mock. The concrete AudioEventHandlerRegistry is
+// constructed only at platform bootstrap (AudioAPIModule / WPT install).
 
 namespace audioapi {
 

--- a/packages/react-native-audio-api/ios/audioapi/ios/core/IOSAudioRecorder.h
+++ b/packages/react-native-audio-api/ios/audioapi/ios/core/IOSAudioRecorder.h
@@ -24,12 +24,12 @@ namespace audioapi {
 class RecorderCallback;
 class RecorderAdapterNode;
 class AudioFileProperties;
-class AudioEventHandlerRegistry;
+class IAudioEventHandlerRegistry;
 class AudioFileWriter;
 
 class IOSAudioRecorder : public AudioRecorder {
  public:
-  IOSAudioRecorder(const std::shared_ptr<AudioEventHandlerRegistry> &audioEventHandlerRegistry);
+  IOSAudioRecorder(const std::shared_ptr<IAudioEventHandlerRegistry> &audioEventHandlerRegistry);
   ~IOSAudioRecorder() override;
 
   Result<NoneType, std::string> start(const std::string &fileNameOverride = "") override;

--- a/packages/react-native-audio-api/ios/audioapi/ios/core/IOSAudioRecorder.mm
+++ b/packages/react-native-audio-api/ios/audioapi/ios/core/IOSAudioRecorder.mm
@@ -12,7 +12,7 @@
 #include <audioapi/core/utils/Constants.h>
 #include <audioapi/core/utils/Locker.h>
 #include <audioapi/dsp/VectorMath.h>
-#include <audioapi/events/AudioEventHandlerRegistry.h>
+#include <audioapi/events/IAudioEventHandlerRegistry.h>
 #include <audioapi/ios/core/IOSAudioRecorder.h>
 #include <audioapi/ios/core/utils/IOSFileWriter.h>
 #include <audioapi/ios/core/utils/IOSRecorderCallback.h>
@@ -102,9 +102,9 @@ static void cleanupStartedRecorder(
 /// This constructor initializes the receiver block and native side recorder wrapper (AVAudioSinkNode).
 /// All other necessary fields (like buffers) are initialized in start() method.
 /// This "method" should be called from the JS thread only.
-/// @param audioEventHandlerRegistry Shared pointer to the AudioEventHandlerRegistry for event handling.
+/// @param audioEventHandlerRegistry Shared pointer to the IAudioEventHandlerRegistry for event handling.
 IOSAudioRecorder::IOSAudioRecorder(
-    const std::shared_ptr<AudioEventHandlerRegistry> &audioEventHandlerRegistry)
+    const std::shared_ptr<IAudioEventHandlerRegistry> &audioEventHandlerRegistry)
     : AudioRecorder(audioEventHandlerRegistry)
 {
   AudioReceiverBlock receiverBlock = ^(const AudioBufferList *inputBuffer, int numFrames) {

--- a/packages/react-native-audio-api/ios/audioapi/ios/core/utils/IOSFileWriter.h
+++ b/packages/react-native-audio-api/ios/audioapi/ios/core/utils/IOSFileWriter.h
@@ -28,12 +28,12 @@ struct WriterData {
 namespace audioapi {
 
 class AudioFileProperties;
-class AudioEventHandlerRegistry;
+class IAudioEventHandlerRegistry;
 
 class IOSFileWriter : public AudioFileWriter {
  public:
   IOSFileWriter(
-      const std::shared_ptr<AudioEventHandlerRegistry> &audioEventHandlerRegistry,
+      const std::shared_ptr<IAudioEventHandlerRegistry> &audioEventHandlerRegistry,
       const std::shared_ptr<AudioFileProperties> &fileProperties);
   ~IOSFileWriter() override;
 

--- a/packages/react-native-audio-api/ios/audioapi/ios/core/utils/IOSFileWriter.mm
+++ b/packages/react-native-audio-api/ios/audioapi/ios/core/utils/IOSFileWriter.mm
@@ -1,7 +1,7 @@
 #import <AVFoundation/AVFoundation.h>
 #import <Foundation/Foundation.h>
 
-#include <audioapi/events/AudioEventHandlerRegistry.h>
+#include <audioapi/events/IAudioEventHandlerRegistry.h>
 #include <audioapi/ios/core/utils/FileOptions.h>
 #include <audioapi/ios/core/utils/IOSFileWriter.h>
 #include <audioapi/ios/core/utils/OwnedAudioBufferList.h>
@@ -17,7 +17,7 @@ using ios::copyIntoOwnedAudioBufferList;
 using ios::OwnedAudioBufferListPtr;
 
 IOSFileWriter::IOSFileWriter(
-    const std::shared_ptr<AudioEventHandlerRegistry> &audioEventHandlerRegistry,
+    const std::shared_ptr<IAudioEventHandlerRegistry> &audioEventHandlerRegistry,
     const std::shared_ptr<AudioFileProperties> &fileProperties)
     : AudioFileWriter(audioEventHandlerRegistry, fileProperties)
 {

--- a/packages/react-native-audio-api/ios/audioapi/ios/core/utils/IOSRecorderCallback.h
+++ b/packages/react-native-audio-api/ios/audioapi/ios/core/utils/IOSRecorderCallback.h
@@ -22,12 +22,12 @@ struct CallbackData {
 
 namespace audioapi {
 
-class AudioEventHandlerRegistry;
+class IAudioEventHandlerRegistry;
 
 class IOSRecorderCallback : public AudioRecorderCallback {
  public:
   IOSRecorderCallback(
-      const std::shared_ptr<AudioEventHandlerRegistry> &audioEventHandlerRegistry,
+      const std::shared_ptr<IAudioEventHandlerRegistry> &audioEventHandlerRegistry,
       float sampleRate,
       size_t bufferLength,
       int channelCount,

--- a/packages/react-native-audio-api/ios/audioapi/ios/core/utils/IOSRecorderCallback.mm
+++ b/packages/react-native-audio-api/ios/audioapi/ios/core/utils/IOSRecorderCallback.mm
@@ -4,7 +4,7 @@
 #include <audioapi/HostObjects/sources/AudioBufferHostObject.h>
 #include <audioapi/core/utils/Constants.h>
 #include <audioapi/dsp/VectorMath.h>
-#include <audioapi/events/AudioEventHandlerRegistry.h>
+#include <audioapi/events/IAudioEventHandlerRegistry.h>
 #include <audioapi/ios/core/utils/IOSRecorderCallback.h>
 #include <audioapi/ios/core/utils/OwnedAudioBufferList.h>
 #include <audioapi/utils/AudioArray.hpp>
@@ -22,7 +22,7 @@ using ios::copyIntoOwnedAudioBufferList;
 using ios::OwnedAudioBufferListPtr;
 
 IOSRecorderCallback::IOSRecorderCallback(
-    const std::shared_ptr<AudioEventHandlerRegistry> &audioEventHandlerRegistry,
+    const std::shared_ptr<IAudioEventHandlerRegistry> &audioEventHandlerRegistry,
     float sampleRate,
     size_t bufferLength,
     int channelCount,

--- a/packages/react-native-audio-api/ios/audioapi/ios/core/utils/IOSRotatingFileWriter.h
+++ b/packages/react-native-audio-api/ios/audioapi/ios/core/utils/IOSRotatingFileWriter.h
@@ -20,7 +20,7 @@ class IOSRotatingFileWriter : public IOSFileWriter, public RotatingFileWriter {
       std::function<std::shared_ptr<AudioFileWriter>(const std::shared_ptr<AudioFileProperties> &)>;
 
   IOSRotatingFileWriter(
-      const std::shared_ptr<AudioEventHandlerRegistry> &audioEventHandlerRegistry,
+      const std::shared_ptr<IAudioEventHandlerRegistry> &audioEventHandlerRegistry,
       const std::shared_ptr<AudioFileProperties> &fileProperties,
       size_t rotateIntervalBytes,
       WriterFactory writerFactory,

--- a/packages/react-native-audio-api/ios/audioapi/ios/core/utils/IOSRotatingFileWriter.mm
+++ b/packages/react-native-audio-api/ios/audioapi/ios/core/utils/IOSRotatingFileWriter.mm
@@ -3,7 +3,7 @@
 #include <audioapi/core/utils/AudioFileWriter.h>
 #include <audioapi/core/utils/RotatingFileWriter.h>
 
-#include <audioapi/events/AudioEventHandlerRegistry.h>
+#include <audioapi/events/IAudioEventHandlerRegistry.h>
 #include <audioapi/ios/core/utils/IOSFileWriter.h>
 #include <audioapi/ios/core/utils/IOSRotatingFileWriter.h>
 #include <audioapi/utils/AudioFileProperties.h>
@@ -15,7 +15,7 @@
 namespace audioapi {
 
 IOSRotatingFileWriter::IOSRotatingFileWriter(
-    const std::shared_ptr<AudioEventHandlerRegistry> &audioEventHandlerRegistry,
+    const std::shared_ptr<IAudioEventHandlerRegistry> &audioEventHandlerRegistry,
     const std::shared_ptr<AudioFileProperties> &fileProperties,
     size_t rotateIntervalBytes,
     WriterFactory writerFactory,

--- a/packages/react-native-audio-api/wpt_tests/src/jsi_install.cpp
+++ b/packages/react-native-audio-api/wpt_tests/src/jsi_install.cpp
@@ -9,6 +9,7 @@
 #include <audioapi/HostObjects/events/AudioEventHandlerRegistryHostObject.h>
 #include <audioapi/HostObjects/sources/AudioBufferHostObject.h>
 #include <audioapi/events/AudioEventHandlerRegistry.h>
+#include <audioapi/events/IAudioEventHandlerRegistry.h>
 #include <audioapi/utils/AudioBuffer.hpp>
 #include <jsi/jsi.h>
 
@@ -24,6 +25,7 @@ using audioapi::AudioBufferHostObject;
 using audioapi::AudioContextHostObject;
 using audioapi::AudioEventHandlerRegistry;
 using audioapi::AudioEventHandlerRegistryHostObject;
+using audioapi::IAudioEventHandlerRegistry;
 using audioapi::OfflineAudioContextHostObject;
 using facebook::jsi::Function;
 using facebook::jsi::JSError;
@@ -108,7 +110,7 @@ void parseOfflineContextArgs(
 
 void installOfflineBindings(
     Runtime &runtime,
-    const std::shared_ptr<AudioEventHandlerRegistry> &eventRegistry,
+    const std::shared_ptr<IAudioEventHandlerRegistry> &eventRegistry,
     const std::shared_ptr<SyncCallInvoker> &callInvoker) {
   auto createOfflineAudioContext = Function::createFromHostFunction(
       runtime,
@@ -165,7 +167,7 @@ void installOfflineBindings(
 
 void installAudioContextBinding(
     Runtime &runtime,
-    const std::shared_ptr<AudioEventHandlerRegistry> &eventRegistry,
+    const std::shared_ptr<IAudioEventHandlerRegistry> &eventRegistry,
     const std::shared_ptr<SyncCallInvoker> &callInvoker) {
   auto createAudioContext = Function::createFromHostFunction(
       runtime,
@@ -206,7 +208,7 @@ void installUnsupportedGlobal(Runtime &runtime, const char *name) {
 
 void installAudioEventEmitter(
     Runtime &runtime,
-    const std::shared_ptr<AudioEventHandlerRegistry> &eventRegistry) {
+    const std::shared_ptr<IAudioEventHandlerRegistry> &eventRegistry) {
   auto eventEmitter = std::make_shared<AudioEventHandlerRegistryHostObject>(eventRegistry);
   runtime.global().setProperty(
       runtime,

--- a/packages/react-native-audio-worklets/common/cpp/audioworklets/AudioWorkletsInstaller.h
+++ b/packages/react-native-audio-worklets/common/cpp/audioworklets/AudioWorkletsInstaller.h
@@ -10,7 +10,7 @@
 #include <worklets/WorkletRuntime/WorkletRuntime.h>
 
 #include <audioapi/HostObjects/events/AudioEventHandlerRegistryHostObject.h>
-#include <audioapi/events/AudioEventHandlerRegistry.h>
+#include <audioapi/events/IAudioEventHandlerRegistry.h>
 
 #include <jsi/jsi.h>
 #include <memory>
@@ -69,7 +69,7 @@ class AudioWorkletsInstaller {
   }
 
  private:
-  static std::shared_ptr<audioapi::AudioEventHandlerRegistry> getAudioEventHandlerRegistryOrThrow(
+  static std::shared_ptr<audioapi::IAudioEventHandlerRegistry> getAudioEventHandlerRegistryOrThrow(
       jsi::Runtime &runtime) {
     auto emitter = runtime.global().getProperty(runtime, "AudioEventEmitter");
     if (!emitter.isObject()) {


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## ⚠️ Breaking changes ⚠️

<!-- A brief description of the breaking changes -->

- None for the public JS/TS API. This is an internal C++ refactor only.
- **Internal C++ only:** any out-of-tree code that constructed or stored `std::shared_ptr<AudioEventHandlerRegistry>` in recorder/file-writer/HostObject/installer paths must switch to `std::shared_ptr<IAudioEventHandlerRegistry>`. Platform bootstrap (`AudioAPIModule` on iOS/Android, WPT install) still constructs the concrete `AudioEventHandlerRegistry`.

## Introduced changes

- Switched consumer modules from `AudioEventHandlerRegistry` to `IAudioEventHandlerRegistry` across the recorder stack (`AudioRecorder`, platform recorders/callbacks), file-writer stack (common + Android/iOS backends, including FFmpeg/MiniAudio/rotating writers), and related HostObjects (`AudioRecorderHostObject`, `AudioEventHandlerRegistryHostObject`).
- Updated `AudioAPIModuleInstaller` and `AudioWorkletsInstaller` to accept/pass the interface type through JSI wiring.
- Removed unnecessary concrete-registry includes from source nodes and `BaseAudioContext` that only forwarded `getAudioEventHandlerRegistry()`.
- Updated WPT install pass-through signatures and `IOSAudioRecorderTests` to use the interface type.
- Clarified `IAudioEventHandlerRegistry` documentation and added a repo-level note in `CLAUDE.md` about interface-at-consumers / concrete-at-bootstrap.

**Unchanged:** `AudioEventHandlerRegistry` is still constructed only at platform bootstrap (`AudioAPIModule` / WPT). No runtime behavior change — all call sites already used the four interface methods (typically via `EventCaller`).

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added/Conducted relevant tests
- [x] Performed self-review of the code
- [ ] Updated Web Audio API coverage
- [ ] Added support for web
- [ ] Updated old arch android spec file

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>