### PR TITLE
build(audioworklets): `cpp` search paths for `mac catalyst` builds

### DIFF
--- a/packages/react-native-audio-worklets/RNAudioWorklets.podspec
+++ b/packages/react-native-audio-worklets/RNAudioWorklets.podspec
@@ -33,6 +33,7 @@ Pod::Spec.new do |s|
     "USE_HEADERMAP" => "YES",
     "DEFINES_MODULE" => "YES",
     "HEADER_SEARCH_PATHS" => [
+      '"$(PODS_TARGET_SRCROOT)/common/cpp"',
       '"$(PODS_TARGET_SRCROOT)/ReactCommon"',
       '"$(PODS_TARGET_SRCROOT)"',
       '"$(PODS_ROOT)/RCT-Folly"',


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## ⚠️ Breaking changes ⚠️

<!-- A brief description of the breaking changes -->

- N/A

## Introduced changes

<!-- A brief description of the changes -->

- added `common/cpp/` to search path in `RNAudioWorklets.podspec` so that `mac catalyst` builds can successfully discover the header files.

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added/Conducted relevant tests
- [ ] Performed self-review of the code
- [ ] Updated Web Audio API coverage
- [ ] Added support for web
- [ ] Updated old arch android spec file
