### PR TITLE
fix(ios): enable voice-processing I/O (echo cancellation) for voiceChat/videoChat session modes

### DIFF
--- a/packages/react-native-audio-api/ios/audioapi/ios/system/AudioEngine.mm
+++ b/packages/react-native-audio-api/ios/audioapi/ios/system/AudioEngine.mm
@@ -38,6 +38,7 @@
 - (AVAudioFormat *)currentInputConnectionFormat;
 - (void)materializeSourceNodeWithId:(NSString *)sourceNodeId;
 - (BOOL)materializeInputNodeIfNeeded;
+- (void)syncVoiceProcessingWithSessionMode;
 - (void)materializeTrackedNodesIfNeeded;
 
 - (AVAudioFormat *)liveInputFormat;
@@ -186,6 +187,8 @@ static AudioEngine *_sharedInstance = nil;
     return YES;
   }
 
+  [self syncVoiceProcessingWithSessionMode];
+
   AVAudioFormat *inputFormat = [self currentInputConnectionFormat];
 
   if (inputFormat == nil) {
@@ -197,6 +200,33 @@ static AudioEngine *_sharedInstance = nil;
   [self.audioEngine attachNode:self.inputNode];
   [self.audioEngine connect:self.audioEngine.inputNode to:self.inputNode format:inputFormat];
   return YES;
+}
+
+// Voice-chat session modes imply Apple's voice-processing I/O (echo
+// cancellation, noise suppression, AGC). Without it, speaker output loops back
+// into the microphone — full-duplex apps (VoIP, voice agents) hear themselves
+// and speech detection self-triggers. Must run before the input format is read
+// (voice processing changes the hardware format) and while the engine is
+// stopped.
+- (void)syncVoiceProcessingWithSessionMode
+{
+  AVAudioSessionMode mode = self.sessionManager.desiredMode;
+  BOOL wantsVoiceProcessing = [mode isEqualToString:AVAudioSessionModeVoiceChat] ||
+      [mode isEqualToString:AVAudioSessionModeVideoChat];
+
+  AVAudioInputNode *systemInputNode = self.audioEngine.inputNode;
+  if (systemInputNode.isVoiceProcessingEnabled == wantsVoiceProcessing) {
+    return;
+  }
+
+  if (self.audioEngine.isRunning) {
+    [self.audioEngine stop];
+  }
+
+  NSError *vpError = nil;
+  if (![systemInputNode setVoiceProcessingEnabled:wantsVoiceProcessing error:&vpError]) {
+    NSLog(@"[AudioEngine] setVoiceProcessingEnabled:%d failed: %@", wantsVoiceProcessing, vpError);
+  }
 }
 
 - (void)materializeTrackedNodesIfNeeded


### PR DESCRIPTION
## Problem

Setting `AudioManager.setAudioSessionOptions({ iosMode: 'voiceChat', ... })` configures AVAudioSession routing and EQ, but does **not** enable echo cancellation — that requires `setVoiceProcessingEnabled:` on the engine's input node, which the library never calls.

Consequence for any full-duplex app (simultaneous `AudioRecorder` capture + playback, e.g. VoIP or realtime voice-agent clients): speaker output loops straight back into the microphone stream. Downstream VAD (local or server-side, e.g. speech-to-speech APIs with barge-in) detects the app's own playback as user speech, so the agent interrupts itself — in my testing this manifested as playback chopped into ~1s fragments as the remote VAD repeatedly fired on the echo. Developers setting `voiceChat` mode almost universally expect AEC to be part of the deal, which makes this a silent trap.

## Fix

When the input node is materialized, sync Apple's voice-processing I/O (AEC + noise suppression + AGC) with the desired session mode: enabled for `voiceChat`/`videoChat`, disabled otherwise. No public API change.

Ordering constraints handled:
- runs **before** `currentInputConnectionFormat` is read — enabling voice processing changes the hardware format;
- only toggles while the engine is stopped (`setVoiceProcessingEnabled:` fails on a running engine);
- no-ops when the state already matches, and syncs both ways so leaving voice-chat mode restores the raw path.

## Testing

Verified on device (iPhone, iOS 26): with `iosCategory: 'playAndRecord'`, `iosMode: 'voiceChat'`, streaming 16 kHz mic PCM via `AudioRecorder.onAudioReady` while playing 24 kHz PCM through an `AudioBufferQueueSourceNode` on the built-in speaker at full volume:
- before: remote VAD fired continuously on echo; playback self-interrupted every ~1s;
- after: zero echo-triggered VAD events over multi-minute sessions; deliberate talk-over (barge-in) still detected correctly.

Known inherent side effect of Apple's voice processing (documented behavior, not introduced by this PR beyond enabling the unit): slight output level reduction on the speaker route.

I first shipped this as a `pnpm patch` against 0.13.2 (enable-only variant) and it's been solid; this PR is the upstreamed, mode-synced version. Happy to rework it as an explicit opt-in option (e.g. a `SessionOptions` flag) if you'd rather not tie it to the session mode — mode-implied seemed like the least-surprise default since `voiceChat` without AEC is rarely what anyone wants.