### PR TITLE
build: add separate type declaration files

### DIFF
--- a/packages/react-native-audio-api/package.json
+++ b/packages/react-native-audio-api/package.json
@@ -8,11 +8,15 @@
   "sideEffects": false,
   "exports": {
     ".": {
-      "types": "./lib/typescript/index.d.ts",
       "react-native": "./src/index.ts",
-      "import": "./lib/module/index.js",
-      "require": "./lib/commonjs/index.js",
-      "default": "./lib/module/index.js"
+      "import": {
+        "types": "./lib/typescript/module/index.d.ts",
+        "default": "./lib/module/index.js"
+      },
+      "require": {
+        "types": "./lib/typescript/commonjs/index.d.ts",
+        "default": "./lib/commonjs/index.js"
+      }
     },
     "./app.plugin.js": "./app.plugin.js",
     "./package.json": "./package.json"
@@ -25,7 +29,7 @@
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",
   "react-native": "src/index.ts",
-  "types": "lib/typescript/index.d.ts",
+  "types": "./lib/typescript/commonjs/index.d.ts",
   "files": [
     "src/",
     "development/react/",
@@ -200,7 +204,9 @@
         "typescript",
         {
           "project": "tsconfig.json",
-          "tsc": "../../node_modules/.bin/tsc"
+          "tsc": "../../node_modules/.bin/tsc",
+          "esm": true,
+          "commonjs": true
         }
       ]
     ]

--- a/packages/react-native-audio-api/package.json
+++ b/packages/react-native-audio-api/package.json
@@ -29,7 +29,7 @@
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",
   "react-native": "src/index.ts",
-  "types": "./lib/typescript/commonjs/index.d.ts",
+  "types": "lib/typescript/commonjs/index.d.ts",
   "files": [
     "src/",
     "development/react/",

--- a/packages/react-native-audio-api/package.json
+++ b/packages/react-native-audio-api/package.json
@@ -8,12 +8,19 @@
   "sideEffects": false,
   "exports": {
     ".": {
-      "react-native": "./src/index.ts",
-      "import": {
+      "react-native": {
         "types": "./lib/typescript/module/index.d.ts",
         "default": "./lib/module/index.js"
       },
-      "require": {
+      "module": {
+        "types": "./lib/typescript/module/index.d.ts",
+        "default": "./lib/module/index.js"
+      },
+      "module-sync": {
+        "types": "./lib/typescript/module/index.d.ts",
+        "default": "./lib/module/index.js"
+      },
+      "default": {
         "types": "./lib/typescript/commonjs/index.d.ts",
         "default": "./lib/commonjs/index.js"
       }


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## ⚠️ Breaking changes ⚠️

<!-- A brief description of the breaking changes -->

- N/A

## Introduced changes

<!-- A brief description of the changes -->

- split `type` routes in `exports` so that there is a clean distinction between `CommonJS` and `ESM`
- refactored `exports` into an alternative approach, so that the [dual package hazard](https://nodejs.org/docs/latest-v19.x/api/packages.html#dual-package-hazard) is minimized

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [x] Added/Conducted relevant tests
- [x] Performed self-review of the code
- [ ] Updated Web Audio API coverage
- [ ] Added support for web
- [ ] Updated old arch android spec file
