### PR TITLE
refactor: split the context state to render and control threads

### DIFF
--- a/packages/react-native-audio-api/common/cpp/audioapi/HostObjects/BaseAudioContextHostObject.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/HostObjects/BaseAudioContextHostObject.cpp
@@ -47,7 +47,6 @@ BaseAudioContextHostObject::BaseAudioContextHostObject(
   addGetters(
       JSI_EXPORT_PROPERTY_GETTER(BaseAudioContextHostObject, destination),
       JSI_EXPORT_PROPERTY_GETTER(BaseAudioContextHostObject, listener),
-      JSI_EXPORT_PROPERTY_GETTER(BaseAudioContextHostObject, state),
       JSI_EXPORT_PROPERTY_GETTER(BaseAudioContextHostObject, sampleRate),
       JSI_EXPORT_PROPERTY_GETTER(BaseAudioContextHostObject, currentTime));
 
@@ -83,11 +82,6 @@ JSI_PROPERTY_GETTER_IMPL(BaseAudioContextHostObject, destination) {
 
 JSI_PROPERTY_GETTER_IMPL(BaseAudioContextHostObject, listener) {
   return jsi::Object::createFromHostObject(runtime, listener_);
-}
-
-JSI_PROPERTY_GETTER_IMPL(BaseAudioContextHostObject, state) {
-  return jsi::String::createFromUtf8(
-      runtime, js_enum_parser::contextStateToString(context_->getState()));
 }
 
 JSI_PROPERTY_GETTER_IMPL(BaseAudioContextHostObject, sampleRate) {

--- a/packages/react-native-audio-api/common/cpp/audioapi/HostObjects/BaseAudioContextHostObject.h
+++ b/packages/react-native-audio-api/common/cpp/audioapi/HostObjects/BaseAudioContextHostObject.h
@@ -27,7 +27,6 @@ class BaseAudioContextHostObject : public HostObject {
 
   JSI_PROPERTY_GETTER_DECL(destination);
   JSI_PROPERTY_GETTER_DECL(listener);
-  JSI_PROPERTY_GETTER_DECL(state);
   JSI_PROPERTY_GETTER_DECL(sampleRate);
   JSI_PROPERTY_GETTER_DECL(currentTime);
 

--- a/packages/react-native-audio-api/common/cpp/audioapi/HostObjects/utils/JsEnumParser.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/HostObjects/utils/JsEnumParser.cpp
@@ -152,19 +152,6 @@ AudioEvent audioEventFromString(const std::string &event) {
   throw std::invalid_argument("Unknown audio event: " + event);
 }
 
-std::string contextStateToString(ContextState state) {
-  switch (state) {
-    case ContextState::SUSPENDED:
-      return "suspended";
-    case ContextState::RUNNING:
-      return "running";
-    case ContextState::CLOSED:
-      return "closed";
-    default:
-      throw std::invalid_argument("Unknown context state");
-  }
-}
-
 std::string channelCountModeToString(ChannelCountMode mode) {
   switch (mode) {
     case ChannelCountMode::MAX:

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/AudioContext.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/AudioContext.cpp
@@ -129,7 +129,7 @@ bool AudioContext::resume(const std::shared_ptr<ContextPromiseResolver<void>> &p
   }
 
   if (result) {
-    // Visible RUNNING is applied in the promise resolve task (CallInvoker).
+    // Visible RUNNING is applied inside the resolver
     ContextPromiseResolver<void>::resolve(promise);
   } else {
     ContextPromiseResolver<void>::reject(promise, "Failed to resume audio context.");
@@ -155,7 +155,7 @@ bool AudioContext::suspend(const std::shared_ptr<ContextPromiseResolver<void>> &
     processAudioEvents();
   }
 
-  // Visible SUSPENDED is applied in the promise resolve task (CallInvoker).
+  // Visible SUSPENDED is applied inside the resolver
   ContextPromiseResolver<void>::resolve(promise);
   return true;
 }

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioScheduledSourceNode.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioScheduledSourceNode.cpp
@@ -25,14 +25,6 @@ AudioScheduledSourceNode::AudioScheduledSourceNode(
       onEndedEvent_(context->getAudioEventHandlerRegistry()) {}
 
 void AudioScheduledSourceNode::start(double when) {
-#if !RN_AUDIO_API_TEST
-  if (std::shared_ptr<BaseAudioContext> context = context_.lock()) {
-    if (auto *audioContext = dynamic_cast<AudioContext *>(context.get())) {
-      audioContext->start();
-    }
-  }
-#endif // RN_AUDIO_API_TEST
-
   playbackState_ = PlaybackState::SCHEDULED;
   startTime_ = when;
 }

--- a/packages/react-native-audio-api/src/core/AudioContext.ts
+++ b/packages/react-native-audio-api/src/core/AudioContext.ts
@@ -29,29 +29,29 @@ export default class AudioContext extends BaseAudioContext {
   }
 
   async close(): Promise<undefined> {
-    if (this.contextState === 'closed') {
+    if (this._state === 'closed') {
       throw new InvalidStateError('Cannot close a closed audio context.');
     }
 
-    this.contextState = 'closed';
+    this._state = 'closed';
     return (this.context as IAudioContext).close();
   }
 
   async resume(): Promise<undefined> {
-    if (this.contextState === 'closed') {
+    if (this._state === 'closed') {
       throw new InvalidStateError('Cannot resume a closed audio context.');
     }
 
-    this.contextState = 'running';
+    this._state = 'running';
     return (this.context as IAudioContext).resume();
   }
 
   async suspend(): Promise<undefined> {
-    if (this.contextState === 'closed') {
+    if (this._state === 'closed') {
       throw new InvalidStateError('Cannot suspend a closed audio context.');
     }
 
-    this.contextState = 'suspended';
+    this._state = 'suspended';
     return (this.context as IAudioContext).suspend();
   }
 
@@ -61,8 +61,8 @@ export default class AudioContext extends BaseAudioContext {
    * carry the transition, so this publishes the state that follows.
    */
   public override markRunningOnSourceStart(): void {
-    if (this.contextState === 'suspended') {
-      this.contextState = 'running';
+    if (this._state === 'suspended') {
+      this._state = 'running';
       (this.context as IAudioContext).resume();
     }
   }

--- a/packages/react-native-audio-api/src/core/AudioContext.ts
+++ b/packages/react-native-audio-api/src/core/AudioContext.ts
@@ -1,3 +1,4 @@
+import { InvalidStateError } from '../errors';
 import { assertSupportedSampleRate } from '../utils/validation';
 import { AudioTagHandle } from '../Audio/types';
 import { IAudioContext } from '../jsi-interfaces';
@@ -28,14 +29,29 @@ export default class AudioContext extends BaseAudioContext {
   }
 
   async close(): Promise<undefined> {
+    if (this.contextState === 'closed') {
+      throw new InvalidStateError('Cannot close a closed audio context.');
+    }
+
+    this.contextState = 'closed';
     return (this.context as IAudioContext).close();
   }
 
   async resume(): Promise<undefined> {
+    if (this.contextState === 'closed') {
+      throw new InvalidStateError('Cannot resume a closed audio context.');
+    }
+
+    this.contextState = 'running';
     return (this.context as IAudioContext).resume();
   }
 
   async suspend(): Promise<undefined> {
+    if (this.contextState === 'closed') {
+      throw new InvalidStateError('Cannot suspend a closed audio context.');
+    }
+
+    this.contextState = 'suspended';
     return (this.context as IAudioContext).suspend();
   }
 

--- a/packages/react-native-audio-api/src/core/AudioContext.ts
+++ b/packages/react-native-audio-api/src/core/AudioContext.ts
@@ -55,6 +55,17 @@ export default class AudioContext extends BaseAudioContext {
     return (this.context as IAudioContext).suspend();
   }
 
+  /**
+   * @internal Called by AudioScheduledSourceNode.start(). The native driver
+   * can start implicitly from the first scheduled source, with no promise to
+   * carry the transition, so this publishes the state that follows.
+   */
+  public override markRunningOnSourceStart(): void {
+    if (this.contextState === 'suspended') {
+      this.contextState = 'running';
+    }
+  }
+
   createMediaElementSource(
     mediaElement: AudioTagHandle
   ): MediaElementAudioSourceNode {

--- a/packages/react-native-audio-api/src/core/AudioContext.ts
+++ b/packages/react-native-audio-api/src/core/AudioContext.ts
@@ -63,6 +63,7 @@ export default class AudioContext extends BaseAudioContext {
   public override markRunningOnSourceStart(): void {
     if (this.contextState === 'suspended') {
       this.contextState = 'running';
+      (this.context as IAudioContext).resume();
     }
   }
 

--- a/packages/react-native-audio-api/src/core/AudioScheduledSourceNode.ts
+++ b/packages/react-native-audio-api/src/core/AudioScheduledSourceNode.ts
@@ -25,6 +25,7 @@ export default class AudioScheduledSourceNode extends AudioNode {
 
     this.hasBeenStarted = true;
     (this.node as IAudioScheduledSourceNode).start(when);
+    this.context.markRunningOnSourceStart();
   }
 
   public stop(when: number = 0): void {

--- a/packages/react-native-audio-api/src/core/BaseAudioContext.ts
+++ b/packages/react-native-audio-api/src/core/BaseAudioContext.ts
@@ -48,12 +48,13 @@ export default class BaseAudioContext {
     return this.contextState;
   }
 
-  /* @internal Called by AudioScheduledSourceNode.start(). */
-  public markRunningOnSourceStart(): void {
-    if (this.contextState === 'suspended') {
-      this.contextState = 'running';
-    }
-  }
+  /**
+   * @internal Called by AudioScheduledSourceNode.start(). No-op here: only
+   * AudioContext overrides it, since only AudioContext's native driver can
+   * start implicitly from a source's start() call. OfflineAudioContext only
+   * starts rendering from an explicit startRendering() call.
+   */
+  public markRunningOnSourceStart(): void {}
 
   public async decodeAudioData(
     input: DecodeDataInput,

--- a/packages/react-native-audio-api/src/core/BaseAudioContext.ts
+++ b/packages/react-native-audio-api/src/core/BaseAudioContext.ts
@@ -38,14 +38,14 @@ export default class BaseAudioContext {
     this.sampleRate = context.sampleRate;
   }
 
-  protected contextState: ContextState = 'suspended';
+  protected _state: ContextState = 'suspended';
 
   public get currentTime(): number {
     return this.context.currentTime;
   }
 
   public get state(): ContextState {
-    return this.contextState;
+    return this._state;
   }
 
   /**

--- a/packages/react-native-audio-api/src/core/BaseAudioContext.ts
+++ b/packages/react-native-audio-api/src/core/BaseAudioContext.ts
@@ -38,12 +38,21 @@ export default class BaseAudioContext {
     this.sampleRate = context.sampleRate;
   }
 
+  protected contextState: ContextState = 'suspended';
+
   public get currentTime(): number {
     return this.context.currentTime;
   }
 
   public get state(): ContextState {
-    return this.context.state;
+    return this.contextState;
+  }
+
+  /* @internal Called by AudioScheduledSourceNode.start(). */
+  public markRunningOnSourceStart(): void {
+    if (this.contextState === 'suspended') {
+      this.contextState = 'running';
+    }
   }
 
   public async decodeAudioData(

--- a/packages/react-native-audio-api/src/core/OfflineAudioContext.ts
+++ b/packages/react-native-audio-api/src/core/OfflineAudioContext.ts
@@ -50,13 +50,13 @@ export default class OfflineAudioContext extends BaseAudioContext {
       );
     }
 
-    if (!(this.contextState === 'suspended')) {
+    if (!(this._state === 'suspended')) {
       throw new InvalidStateError(
         'Cannot resume an OfflineAudioContext that is not suspended'
       );
     }
 
-    this.contextState = 'running';
+    this._state = 'running';
     return (this.context as IOfflineAudioContext).resume();
   }
 
@@ -77,10 +77,14 @@ export default class OfflineAudioContext extends BaseAudioContext {
       );
     }
 
+    if (this._state === 'closed') {
+      throw new InvalidStateError('the rendering is already finished');
+    }
+
     const result = await (this.context as IOfflineAudioContext).suspend(
       suspendTime
     );
-    this.contextState = 'suspended';
+    this._state = 'suspended';
     return result;
   }
 
@@ -90,11 +94,11 @@ export default class OfflineAudioContext extends BaseAudioContext {
     }
 
     this.isRendering = true;
-    this.contextState = 'running';
+    this._state = 'running';
     const audioBuffer = await (
       this.context as IOfflineAudioContext
     ).startRendering();
-    this.contextState = 'closed';
+    this._state = 'closed';
 
     return new AudioBuffer(audioBuffer);
   }

--- a/packages/react-native-audio-api/src/core/OfflineAudioContext.ts
+++ b/packages/react-native-audio-api/src/core/OfflineAudioContext.ts
@@ -94,6 +94,7 @@ export default class OfflineAudioContext extends BaseAudioContext {
     const audioBuffer = await (
       this.context as IOfflineAudioContext
     ).startRendering();
+    this.contextState = 'closed';
 
     return new AudioBuffer(audioBuffer);
   }

--- a/packages/react-native-audio-api/src/core/OfflineAudioContext.ts
+++ b/packages/react-native-audio-api/src/core/OfflineAudioContext.ts
@@ -77,8 +77,11 @@ export default class OfflineAudioContext extends BaseAudioContext {
       );
     }
 
+    const result = await (this.context as IOfflineAudioContext).suspend(
+      suspendTime
+    );
     this.contextState = 'suspended';
-    return (this.context as IOfflineAudioContext).suspend(suspendTime);
+    return result;
   }
 
   async startRendering(): Promise<AudioBuffer> {

--- a/packages/react-native-audio-api/src/core/OfflineAudioContext.ts
+++ b/packages/react-native-audio-api/src/core/OfflineAudioContext.ts
@@ -6,7 +6,6 @@ import AudioBuffer from './AudioBuffer';
 import BaseAudioContext from './BaseAudioContext';
 
 export default class OfflineAudioContext extends BaseAudioContext {
-  private isSuspended: boolean;
   private isRendering: boolean;
   private duration: number;
 
@@ -41,7 +40,6 @@ export default class OfflineAudioContext extends BaseAudioContext {
       throw new NotSupportedError('Invalid constructor arguments');
     }
 
-    this.isSuspended = false;
     this.isRendering = false;
   }
 
@@ -52,14 +50,13 @@ export default class OfflineAudioContext extends BaseAudioContext {
       );
     }
 
-    if (!this.isSuspended) {
+    if (!(this.contextState === 'suspended')) {
       throw new InvalidStateError(
         'Cannot resume an OfflineAudioContext that is not suspended'
       );
     }
 
-    this.isSuspended = false;
-
+    this.contextState = 'running';
     return (this.context as IOfflineAudioContext).resume();
   }
 
@@ -80,8 +77,7 @@ export default class OfflineAudioContext extends BaseAudioContext {
       );
     }
 
-    this.isSuspended = true;
-
+    this.contextState = 'suspended';
     return (this.context as IOfflineAudioContext).suspend(suspendTime);
   }
 
@@ -91,7 +87,7 @@ export default class OfflineAudioContext extends BaseAudioContext {
     }
 
     this.isRendering = true;
-
+    this.contextState = 'running';
     const audioBuffer = await (
       this.context as IOfflineAudioContext
     ).startRendering();

--- a/packages/react-native-audio-api/src/jsi-interfaces.ts
+++ b/packages/react-native-audio-api/src/jsi-interfaces.ts
@@ -14,7 +14,6 @@ import type {
   ChannelSplitterOptions,
   ConstantSourceOptions,
   ConvolverOptions,
-  ContextState,
   DelayOptions,
   FileInfo,
   GainOptions,
@@ -40,7 +39,6 @@ export interface IOscillatorOptions extends Omit<
 export interface IBaseAudioContext {
   readonly destination: IAudioDestinationNode;
   readonly listener: IAudioListener;
-  readonly state: ContextState;
   readonly sampleRate: number;
   readonly currentTime: number;
   readonly decoder: IAudioDecoder;


### PR DESCRIPTION
## Problem

### Only js state:
resume() flips the single state to RUNNING synchronously. The actual driver open is async and takes a few ms (Oboe/AVAudioSession — normal, not a failure). JS calls suspend() in that window. The guard reads RUNNING (not SUSPENDED), so it correctly decides to call audioPlayer_->suspend() — but the stream hasn't finished opening yet, so there's nothing real to stop. The stop call lands on a half-initialized stream (no-op, or worse, undefined behavior depending on the SDK); the open then completes moments later and audio starts playing — after suspend() already resolved and JS believes the context is suspended.

### Only audio-thread state:
JS calls ctx.close() twice back-to-back (e.g. a cleanup effect firing twice). The "already closed" guard reads the engine-confirmed value, which hasn't updated yet because the engine hasn't processed either call. Both calls pass the guard and both proceed to release the same driver resources — double-free/double-release.

### Solution

Two unrelated states, one serves as the guard for the unlogic calls, the second one guards internal audio engine to not call two things at the same time