### PR TITLE
feat(ios): support isLiveStream in PlaybackNotificationInfo

### DIFF
--- a/packages/audiodocs/docs/system/playback-notification-manager.mdx
+++ b/packages/audiodocs/docs/system/playback-notification-manager.mdx
@@ -171,6 +171,9 @@ interface PlaybackNotificationInfo {
   state?: 'playing' | 'paused';
 
   skipInterval?: number;
+
+  // IOS only: shows the system "Live" indicator on the lock screen and CarPlay Now Playing UI
+  isLiveStream?: boolean;
 }
 ```
 </details>
@@ -182,6 +185,12 @@ interface PlaybackNotificationInfo {
 - Clamped to `1–120` seconds in JavaScript before being passed to native.
 - Pass `skipInterval` in the same `show()` call (or earlier) before enabling skip controls, so the interval is applied when controls are first set up.
 - On Android, skip action icons show `15` when `skipInterval` is `15` (default); otherwise generic skip icons without a number are used.
+
+#### `isLiveStream`
+
+- Marks the current item as a live stream (e.g. live radio) rather than a track with a known duration.
+- iOS only: maps to `MPNowPlayingInfoPropertyIsLiveStream`, which drives the "Live" label shown on the lock screen and CarPlay Now Playing UI.
+- No effect on Android — there is no equivalent system-level indicator to map it to.
 
 ### `PlaybackControlName`
 

--- a/packages/react-native-audio-api/ios/audioapi/ios/system/notification/PlaybackNotification.mm
+++ b/packages/react-native-audio-api/ios/audioapi/ios/system/notification/PlaybackNotification.mm
@@ -9,7 +9,8 @@
     @"duration" : MPMediaItemPropertyPlaybackDuration, \
     @"elapsedTime" : MPNowPlayingInfoPropertyElapsedPlaybackTime, \
     @"speed" : MPNowPlayingInfoPropertyPlaybackRate, \
-    @"artwork" : MPMediaItemPropertyArtwork \
+    @"artwork" : MPMediaItemPropertyArtwork, \
+    @"isLiveStream" : MPNowPlayingInfoPropertyIsLiveStream \
   }
 
 // Must match PlaybackNotification.DEFAULT_SKIP_INTERVAL_SECONDS on Android.

--- a/packages/react-native-audio-api/src/system/notification/types.ts
+++ b/packages/react-native-audio-api/src/system/notification/types.ts
@@ -37,6 +37,14 @@ export interface PlaybackNotificationInfo {
   state?: 'playing' | 'paused';
   /** Skip interval in seconds for skipForward/skipBackward. Default: 15 */
   skipInterval?: number;
+  /**
+   * Marks the current item as a live stream (e.g. live radio) rather than
+   * a track with a known duration. iOS-only: maps to
+   * `MPNowPlayingInfoPropertyIsLiveStream`, which drives the "Live" label
+   * the system shows on the lock screen and CarPlay Now Playing UI. Has no
+   * effect on Android, which has no equivalent system indicator.
+   */
+  isLiveStream?: boolean;
 }
 
 /// Available playback control actions.

--- a/packages/react-native-audio-api/src/system/notification/types.ts
+++ b/packages/react-native-audio-api/src/system/notification/types.ts
@@ -38,11 +38,11 @@ export interface PlaybackNotificationInfo {
   /** Skip interval in seconds for skipForward/skipBackward. Default: 15 */
   skipInterval?: number;
   /**
-   * Marks the current item as a live stream (e.g. live radio) rather than
-   * a track with a known duration. iOS-only: maps to
-   * `MPNowPlayingInfoPropertyIsLiveStream`, which drives the "Live" label
-   * the system shows on the lock screen and CarPlay Now Playing UI. Has no
-   * effect on Android, which has no equivalent system indicator.
+   * Marks the current item as a live stream (e.g. live radio) rather than a
+   * track with a known duration. iOS-only: maps to
+   * `MPNowPlayingInfoPropertyIsLiveStream`, which drives the "Live" label the
+   * system shows on the lock screen and CarPlay Now Playing UI. Has no effect
+   * on Android, which has no equivalent system indicator.
    */
   isLiveStream?: boolean;
 }


### PR DESCRIPTION
## What

Adds `isLiveStream?: boolean` to `PlaybackNotificationInfo`. On iOS, it's mapped to
`MPNowPlayingInfoPropertyIsLiveStream`, which drives the system "Live" label shown on the lock screen
and in CarPlay's Now Playing UI for content with no fixed duration (live radio, live events, etc.).
No effect on Android — there's no equivalent system-level indicator there.

## Why

For an app playing live radio streams alongside on-demand content, the lock screen currently has no
way to distinguish "live" from "has a real duration" — `duration`/`elapsedTime` are the only signals,
and omitting them just means no scrubber, not an actual "Live" indicator. This is a small, additive
change that closes that gap using the same key-mapping mechanism every other `PlaybackNotificationInfo`
field already uses.

## How

`showNotification`'s native module signature already takes a generic, untyped options map
(`OptionsMap = { [key: string]: string | boolean | number | undefined }` in `NativeAudioAPIModule.ts`),
so no TurboModule/codegen changes are needed on either platform — this follows the exact same path
`title`, `duration`, `skipInterval`, etc. already use.

- `src/system/notification/types.ts` — add the `isLiveStream?: boolean` field.
- `ios/.../PlaybackNotification.mm` — add `@"isLiveStream" : MPNowPlayingInfoPropertyIsLiveStream` to
  the existing `NOW_PLAYING_INFO_KEYS` map. `updateNowPlayingInfo:`'s update loop already writes any
  key present in that map generically, so this one line is the entire native change.
- `packages/audiodocs/docs/system/playback-notification-manager.mdx` — documented the new field
  alongside the existing ones.
- Android untouched deliberately — I read through `PlaybackNotification.kt`'s full show/update path
  and found no rendering surface for a "Live" badge in Android's own `MediaStyle` notification/lock
  screen to map this to; happy to be corrected if there's a convention I'm missing.

## Testing

**I have not yet verified this on a real device** — this is based on reading the source (the
`NOW_PLAYING_INFO_KEYS` mapping table and the generic update loop), not a device/simulator run against
a real lock screen or CarPlay session. Apple's docs note `MPNowPlayingInfoPropertyIsLiveStream` can
affect how the system renders duration/elapsed time alongside it, which I haven't been able to confirm
interacts cleanly with `duration`/`elapsedTime` still being set. If this looks right in principle, I'd
appreciate help confirming actual on-device behavior before merge, or pointers to an existing
test/example app flow I should run it through.

## Notes on process

I know `CONTRIBUTING.md` asks that new-feature PRs be preceded by a design doc — given the change is
additive and small (one optional field, one native mapping entry, no API changes to anything existing),
I've folded the rationale into this description rather than opening a separate doc first. Happy to open
a discussion/issue instead if that's preferred for something this size.
