### PR TITLE
build: update metro config

### DIFF
--- a/apps/fabric-example/metro.config.js
+++ b/apps/fabric-example/metro.config.js
@@ -3,6 +3,10 @@ const path = require('path');
 
 const monorepoRoot = path.resolve(__dirname, '../..');
 const appsRoot = path.resolve(monorepoRoot, 'apps');
+const libraryRoot = path.resolve(
+  monorepoRoot,
+  'packages/react-native-audio-api'
+);
 
 const defaultConfig = getDefaultConfig(__dirname);
 /**
@@ -15,6 +19,17 @@ const config = {
   watchFolders: [monorepoRoot, appsRoot],
   resolver: {
     assetExts: [...defaultConfig.resolver.assetExts, 'ogg', 'flac', 'opus'],
+    resolveRequest: (context, moduleName, platform) => {
+      // Override the consumer resolution to point to the source code
+      // so that there is no need for manual rebuild on every change in TS.
+      if (moduleName === 'react-native-audio-api') {
+        return {
+          filePath: path.resolve(libraryRoot, 'src/index.ts'),
+          type: 'sourceFile',
+        };
+      }
+      return context.resolveRequest(context, moduleName, platform);
+    },
   },
   /* we are rewriting requests because due to monorepo structure, the assets are found with '../../../' prefix
   and we redirect them to the correct path without relative prefixes */

--- a/apps/fabric-example/tsconfig.json
+++ b/apps/fabric-example/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "moduleSuffixes": [".ios", ".android", ".native", ""],
     "paths": {
       "@/*": ["../common-app/src/*"]


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## ⚠️ Breaking changes ⚠️

<!-- A brief description of the breaking changes -->

- N/A

## Introduced changes

<!-- A brief description of the changes -->

- updated `fabric-example/metro.config.js` so that it overrides the consumer resolution to transpiled `JS` files and instead reads source `TS` (metro handles `TS` on the fly) thus allowing for live changes (follows-up changes to package build in #1194 and #1222)
- removed deprecated `baseUrl` field from `fabric-example/tsconfig.json` (kind of stale follow-up of #1099)

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added/Conducted relevant tests
- [x] Performed self-review of the code
- [x] Updated Web Audio API coverage
- [x] Added support for web
- [x] Updated old arch android spec file
